### PR TITLE
Mem backend's Enumerate doesn't raise ErrNotFound

### DIFF
--- a/consul/kv_consul.go
+++ b/consul/kv_consul.go
@@ -606,7 +606,7 @@ func (kv *consulKV) pairToKv(action string, pair *api.KVPair, meta *api.QueryMet
 func isHidden(key string) bool {
 	tokens := strings.Split(key, "/")
 	keySuffix := tokens[len(tokens)-1]
-	return keySuffix[0] == '_'
+	return keySuffix != "" && keySuffix[0] == '_'
 }
 
 func (kv *consulKV) pairToKvs(action string, pairs []*api.KVPair, meta *api.QueryMeta) kvdb.KVPairs {

--- a/mem/kv_mem.go
+++ b/mem/kv_mem.go
@@ -211,6 +211,10 @@ func (kv *memKV) Enumerate(prefix string) (kvdb.KVPairs, error) {
 		}
 	}
 
+	if len(kvp) == 0 {
+		return nil, kvdb.ErrNotFound
+	}
+
 	return kvp, nil
 }
 

--- a/test/kv.go
+++ b/test/kv.go
@@ -289,11 +289,25 @@ func enumerate(kv kvdb.Kvdb, t *testing.T) {
 		kv.DeleteTree(prefix)
 	}()
 
+	errPairs, err := kv.Enumerate(prefix)
+	assert.Equal(t, 0, len(errPairs), "Expected 0 pairs")
+	assert.Equal(t, kvdb.ErrNotFound, err, "ErrNotFound expected")
+
+	folderKey := prefix + "/folder"
+	_, err = kv.Put(folderKey, []byte(""), 0)
+	assert.NoError(t, err, "Unexpected error on Put")
+	kvPairs, err := kv.Enumerate(folderKey)
+	assert.Equal(t, nil, err, "Unexpected error on Enumerate")
+	assert.Equal(t, 1, len(kvPairs), "Expected 1 pairs")
+	assert.Equal(t, folderKey, kvPairs[0].Key,
+		"Unexpected key received")
+	kv.DeleteTree(prefix)
+
 	for key, val := range keys {
 		_, err := kv.Put(key, []byte(val), 0)
 		assert.NoError(t, err, "Unexpected error on Put")
 	}
-	kvPairs, err := kv.Enumerate(prefix)
+	kvPairs, err = kv.Enumerate(prefix)
 	assert.NoError(t, err, "Unexpected error on Enumerate")
 
 	assert.Equal(t, len(kvPairs), len(keys),

--- a/test/kv.go
+++ b/test/kv.go
@@ -293,7 +293,7 @@ func enumerate(kv kvdb.Kvdb, t *testing.T) {
 	assert.Equal(t, 0, len(errPairs), "Expected 0 pairs")
 	assert.Equal(t, kvdb.ErrNotFound, err, "ErrNotFound expected")
 
-	folderKey := prefix + "/folder"
+	folderKey := prefix + "/folder/"
 	_, err = kv.Put(folderKey, []byte(""), 0)
 	assert.NoError(t, err, "Unexpected error on Put")
 	kvPairs, err := kv.Enumerate(folderKey)


### PR DESCRIPTION
I'm trying to write a test for https://github.com/libopenstorage/openstorage/pull/162 which uses the Mem datastore for testing, but I get errors in production because I'm using the Consul datastore instead.

Specifically, the [``mem.Enumerate`` never raises the ErrNotFound](https://github.com/portworx/kvdb/blob/master/mem/kv_mem.go#L202) whereas [``consul.Enumerate`` does](https://github.com/portworx/kvdb/blob/master/consul/kv_consul.go#L236) if required. This difference makes it hard to test the behavior of the library consumer when it's using the Consul datastore.

I updated the library to reflect this and updated the Enumerate tests to test this particular behavior. I tested the changes on an empty Consul instance but not with the Etcd backends (I have troubles building the tests otherwise.)

Additionally, the Consul backend wasn't processing correctly key finishing by a /, which was the example used in the test.