### PR TITLE
PWX-2776: Fixing type-cast issue for etcd2.Get() error

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,3 +10,4 @@ This library abstracts the caller from the specific key-value database implement
 * `Etcd v3`
 * `Consul`
 * `In-memory store`
+

--- a/etcd/common/common.go
+++ b/etcd/common/common.go
@@ -42,6 +42,7 @@ type EtcdCommon interface {
 	GetRetryCount() int
 }
 
+// EtcdLock combines Mutex and channel
 type EtcdLock struct {
 	Done     chan struct{}
 	Unlocked bool
@@ -188,7 +189,7 @@ func Version(url string, options map[string]string) (string, error) {
 		// This should never happen in an ideal scenario unless
 		// etcd messes up. To avoid a crash further in this code
 		// we return an error
-		return "", fmt.Errorf("Unable to determine etcd version. Got an empty response from etcd.")
+		return "", fmt.Errorf("Unable to determine etcd version (empty response from etcd)")
 	}
 	if version.Server[0] == '2' || version.Server[0] == '1' {
 		return kvdb.EtcdBaseVersion, nil

--- a/etcd/v2/kv_etcd.go
+++ b/etcd/v2/kv_etcd.go
@@ -421,11 +421,13 @@ func (kv *etcdKV) get(key string, recursive, sort bool) (*kvdb.KVPair, error) {
 		case *e.ClusterError:
 			logrus.Errorf("kvdb get error: %v, retry count: %v\n", err, i)
 			time.Sleep(ec.DefaultIntervalBetweenRetries)
-		default:
+		case *e.Error:
 			etcdErr := err.(e.Error)
 			if etcdErr.Code == e.ErrorCodeKeyNotFound {
 				return nil, kvdb.ErrNotFound
 			}
+			return nil, err
+		default:
 			return nil, err
 		}
 	}


### PR DESCRIPTION
Additionally, cleaned up the 'go vet/lint' issues.