### PR TITLE
Add a new type of kvdb mem which stores the values as interfaces instead of byte array.

### DIFF
--- a/kvdb.go
+++ b/kvdb.go
@@ -141,6 +141,15 @@ type DatastoreInit func(domain string, machines []string, options map[string]str
 // DatastoreVersion is called to get the version of a backend KV store
 type DatastoreVersion func(url string, kvdbOptions map[string]string) (string, error)
 
+// EnumerateSelect function is a callback function provided to EnumerateWithSelect API
+// This fn is executed over all the keys and only those values are returned by Enumerate for which
+// this function return true.
+type EnumerateSelect func(val interface{}) (bool, interface{})
+
+// CopySelect function is a callback function provided to EnumerateWithSelect API
+// This fn should perform a deep copy of the input interface and return the copy
+type CopySelect func(val interface{}) interface{}
+
 // KVPair represents the results of an operation on KVDB.
 type KVPair struct {
 	// Key for this kv pair.
@@ -206,6 +215,9 @@ type Kvdb interface {
 	Update(key string, value interface{}, ttl uint64) (*KVPair, error)
 	// Enumerate returns a list of KVPair for all keys that share the specified prefix.
 	Enumerate(prefix string) (KVPairs, error)
+	// EnumerateWithSelect returns a copy of all values under the prefix that satisfy the select
+	// function in the provided output array of interfaces
+	// EnumerateWithSelect(prefix string, enumerateSelect EnumerateSelect, copySelect CopySelect) ([]interface{}, error)
 	// Delete deletes the KVPair specified by the key. ErrNotFound is returned
 	// if the key is not found. The old KVPair is returned if successful.
 	Delete(key string) (*KVPair, error)

--- a/mem/kv_mem_test.go
+++ b/mem/kv_mem_test.go
@@ -7,7 +7,12 @@ import (
 )
 
 func TestAll(t *testing.T) {
-	test.RunBasic(New, t, Start, Stop)
+	options := make(map[string]string)
+	// RunBasic with values as bytes
+	test.RunBasic(New, t, Start, Stop, options)
+	options[KvUseInterface] = ""
+	// RunBasic with values as interface
+	test.RunBasic(New, t, Start, Stop, options)
 }
 
 func Start() error {

--- a/mem/kv_mem_test.go
+++ b/mem/kv_mem_test.go
@@ -1,9 +1,12 @@
 package mem
 
 import (
+	"fmt"
 	"testing"
 
+	"github.com/portworx/kvdb"
 	"github.com/portworx/kvdb/test"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestAll(t *testing.T) {
@@ -13,6 +16,30 @@ func TestAll(t *testing.T) {
 	options[KvUseInterface] = ""
 	// RunBasic with values as interface
 	test.RunBasic(New, t, Start, Stop, options)
+	// Run mem specific tests
+	kv, err := New("pwx/test", nil, options, nil)
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	testNoCopy(kv, t)
+}
+
+func testNoCopy(kv kvdb.Kvdb, t *testing.T) {
+	fmt.Println("testNoCopy")
+	type Test struct {
+		A int
+		B string
+	}
+	val := &Test{1, "abc"}
+	_, err := kv.Put("key1", &val, 0)
+	assert.NoError(t, err, "Expected no error on put")
+	val.A = 2
+	val.B = "def"
+	var newVal Test
+	_, err = kv.GetVal("key1", &newVal)
+	assert.NoError(t, err, "Expected no error on get")
+	assert.Equal(t, newVal.A, val.A, "Expected equal values")
+	assert.Equal(t, newVal.B, val.B, "Expected equal values")
 }
 
 func Start() error {

--- a/mem/kv_mem_test.go
+++ b/mem/kv_mem_test.go
@@ -14,7 +14,7 @@ func TestAll(t *testing.T) {
 	// RunBasic with values as bytes
 	test.RunBasic(New, t, Start, Stop, options)
 	options[KvUseInterface] = ""
-	// RunBasic with values as interface
+	//  RunBasic with values as interface
 	test.RunBasic(New, t, Start, Stop, options)
 	// Run mem specific tests
 	kv, err := New("pwx/test", nil, options, nil)

--- a/test/kv.go
+++ b/test/kv.go
@@ -81,11 +81,11 @@ func Run(datastoreInit kvdb.DatastoreInit, t *testing.T, start StartKvdb, stop S
 }
 
 // RunBasic runs the basic test suite.
-func RunBasic(datastoreInit kvdb.DatastoreInit, t *testing.T, start StartKvdb, stop StopKvdb) {
+func RunBasic(datastoreInit kvdb.DatastoreInit, t *testing.T, start StartKvdb, stop StopKvdb, kvdbOptions map[string]string) {
 	err := start()
 	time.Sleep(3 * time.Second)
 	assert.NoError(t, err, "Unable to start kvdb")
-	kv, err := datastoreInit("pwx/test", nil, nil, fatalErrorCb())
+	kv, err := datastoreInit("pwx/test", nil, kvdbOptions, fatalErrorCb())
 	if err != nil {
 		t.Fatalf(err.Error())
 	}
@@ -861,7 +861,6 @@ func watchUpdate(kv kvdb.Kvdb, data *watchData) error {
 	atomic.SwapInt32(&data.whichKey, 1)
 	data.action = kvdb.KVCreate
 	_, err = kv.Create(data.key, []byte(data.stop), 0)
-
 	return err
 }
 


### PR DESCRIPTION
- Currently does not create a copy of the interface passed in Put, but simply stores it in the map.
- While returning in Get creates a byte array copy of the interface and returns the KVPair

A new API EnumerateWithSelector on its way.