### PR TITLE
Fix a race condition in Snapshot implementation which caused a go panic.

### DIFF
--- a/consul/kv_consul.go
+++ b/consul/kv_consul.go
@@ -654,8 +654,8 @@ func (kv *consulKV) Snapshot(prefix string) (kvdb.Kvdb, uint64, error) {
 			} else {
 				if kvp.Action == kvdb.KVDelete {
 					_, err = snapDb.Delete(kvp.Key)
-					// A Delete key was issued between our Watch and Enumerate
-					// APIs in this function
+					// A Delete key was issued between our first lowestKvdbIndex Put
+					// and Enumerate APIs in this function
 					if err == kvdb.ErrNotFound {
 						err = nil
 					}

--- a/consul/kv_consul.go
+++ b/consul/kv_consul.go
@@ -654,6 +654,12 @@ func (kv *consulKV) Snapshot(prefix string) (kvdb.Kvdb, uint64, error) {
 			} else {
 				if kvp.Action == kvdb.KVDelete {
 					_, err = snapDb.Delete(kvp.Key)
+					// A Delete key was issued between our Watch and Enumerate
+					// APIs in this function
+					if err == kvdb.ErrNotFound {
+						err = nil
+					}
+
 				} else {
 					_, err = snapDb.SnapPut(kvp)
 				}

--- a/etcd/v2/kv_etcd.go
+++ b/etcd/v2/kv_etcd.go
@@ -762,6 +762,11 @@ func (kv *etcdKV) Snapshot(prefix string) (kvdb.Kvdb, uint64, error) {
 			kvPair.ModifiedIndex > lowestKvdbIndex {
 			if kvPair.Action == kvdb.KVDelete {
 				_, err = snapDb.Delete(kvPair.Key)
+				// A Delete key was issued between our Watch and Enumerate
+				// APIs in this function
+				if err == kvdb.ErrNotFound {
+					err = nil
+				}
 			} else {
 				_, err = snapDb.SnapPut(kvPair)
 			}

--- a/etcd/v2/kv_etcd.go
+++ b/etcd/v2/kv_etcd.go
@@ -762,8 +762,8 @@ func (kv *etcdKV) Snapshot(prefix string) (kvdb.Kvdb, uint64, error) {
 			kvPair.ModifiedIndex > lowestKvdbIndex {
 			if kvPair.Action == kvdb.KVDelete {
 				_, err = snapDb.Delete(kvPair.Key)
-				// A Delete key was issued between our Watch and Enumerate
-				// APIs in this function
+				// A Delete key was issued between our first lowestKvdbIndex Put
+				// and Enumerate APIs in this function
 				if err == kvdb.ErrNotFound {
 					err = nil
 				}

--- a/etcd/v3/kv_etcd.go
+++ b/etcd/v3/kv_etcd.go
@@ -1084,6 +1084,11 @@ func (et *etcdKV) Snapshot(prefix string) (kvdb.Kvdb, uint64, error) {
 			kvPair.ModifiedIndex > lowestKvdbIndex {
 			if kvPair.Action == kvdb.KVDelete {
 				_, err = snapDb.Delete(kvPair.Key)
+				// A Delete key was issued between our Watch and Enumerate
+				// APIs in this function
+				if err == kvdb.ErrNotFound {
+					err = nil
+				}
 			} else {
 				_, err = snapDb.SnapPut(kvPair)
 			}

--- a/etcd/v3/kv_etcd.go
+++ b/etcd/v3/kv_etcd.go
@@ -1084,8 +1084,8 @@ func (et *etcdKV) Snapshot(prefix string) (kvdb.Kvdb, uint64, error) {
 			kvPair.ModifiedIndex > lowestKvdbIndex {
 			if kvPair.Action == kvdb.KVDelete {
 				_, err = snapDb.Delete(kvPair.Key)
-				// A Delete key was issued between our Watch and Enumerate
-				// APIs in this function
+				// A Delete key was issued between our first lowestKvdbIndex Put
+				// and Enumerate APIs in this function
 				if err == kvdb.ErrNotFound {
 					err = nil
 				}

--- a/mem/kv_mem.go
+++ b/mem/kv_mem.go
@@ -801,9 +801,13 @@ func (kv *snapMem) Delete(snapKey string) (*kvdb.KVPair, error) {
 	key := kv.domain + snapKey
 	kv.mutex.Lock()
 	defer kv.mutex.Unlock()
-	kvp := kv.m[key]
+	kvp, ok := kv.m[key]
+	if !ok {
+		return nil, kvdb.ErrNotFound
+	}
+	kvPair := kvp.KVPair
 	delete(kv.m, key)
-	return &kvp.KVPair, nil
+	return &kvPair, nil
 }
 
 func (kv *snapMem) DeleteTree(prefix string) error {


### PR DESCRIPTION
- For the following scenario the Snapshot API would panic for any kvdb implementation in snapMem.Delete function

Following is the timeline of calls that Snapshot API does
Time    API
t1 --> Watch
.
.
t2 --> Enumerate
.
t3 --> SnapPut
.
.
t4 --> Apply updates from Watch to snapDB

If there are any Delete calls to the actual kvdb between t1 and t2 those
keys will not be present in the Snapshot in-mem db. However the Watch will
record the Delete request. At t4 while applying the updates we will try to
Delete a non-existent key from snapMem and panic.