### PR TITLE
Handle server timeout during update

### DIFF
--- a/etcd/v3/kv_etcd.go
+++ b/etcd/v3/kv_etcd.go
@@ -491,47 +491,54 @@ func (et *etcdKV) CompareAndSet(
 		opts = append(opts, e.WithLease(leaseResult.ID))
 	}
 
-	ctx, cancel := et.Context()
+	cmp := e.Compare(e.Value(key), "=", string(prevValue))
 	if (flags & kvdb.KVModifiedIndex) != 0 {
-		txnResponse, txnErr = et.kvClient.Txn(ctx).
-			If(e.Compare(e.ModRevision(key), "=", int64(kvp.ModifiedIndex))).
-			Then(e.OpPut(key, string(kvp.Value), opts...)).
-			Commit()
-		cancel()
-		if txnErr != nil {
-			return nil, txnErr
-		}
-		if txnResponse.Succeeded == false {
-			if len(txnResponse.Responses) == 0 {
-				logrus.Infof("Etcd did not return any transaction responses for key (%v)", kvp.Key)
-			} else {
-				for i, responseOp := range txnResponse.Responses {
-					logrus.Infof("Etcd transaction Response: %v %v", i, responseOp.String())
-				}
-			}
-			return nil, kvdb.ErrModified
-		}
-
-	} else {
-		txnResponse, txnErr = et.kvClient.Txn(ctx).
-			If(e.Compare(e.Value(key), "=", string(prevValue))).
-			Then(e.OpPut(key, string(kvp.Value), opts...)).
-			Commit()
-		cancel()
-		if txnErr != nil {
-			return nil, txnErr
-		}
-		if txnResponse.Succeeded == false {
-			if len(txnResponse.Responses) == 0 {
-				logrus.Infof("Etcd did not return any transaction responses for key (%v)", kvp.Key)
-			} else {
-				for i, responseOp := range txnResponse.Responses {
-					logrus.Infof("Etcd transaction Response: %v %v", i, responseOp.String())
-				}
-			}
-			return nil, kvdb.ErrValueMismatch
-		}
+		cmp = e.Compare(e.ModRevision(key), "=", int64(kvp.ModifiedIndex))
 	}
+retry:
+	for {
+		ctx, cancel := et.Context()
+		txnResponse, txnErr = et.kvClient.Txn(ctx).
+			If(cmp).
+			Then(e.OpPut(key, string(kvp.Value), opts...)).
+			Commit()
+		cancel()
+		if txnErr != nil {
+			if strings.Contains(txnErr.Error(), rpctypes.ErrGRPCTimeout.Error()) {
+				// server timeout
+				kvPair, err := et.Get(kvp.Key)
+				if err != nil {
+					return nil, txnErr
+				}
+				if kvPair.ModifiedIndex == kvp.ModifiedIndex {
+					// update did not succeed, retry
+					continue retry
+				} else if bytes.Compare(kvp.Value, kvPair.Value) == 0 {
+					return kvPair, nil
+				}
+				// else someone else updated the value, return error
+			}
+			return nil, txnErr
+		}
+		if txnResponse.Succeeded == false {
+			if len(txnResponse.Responses) == 0 {
+				logrus.Infof("Etcd did not return any transaction responses "+
+					"for key (%v)", kvp.Key)
+			} else {
+				for i, responseOp := range txnResponse.Responses {
+					logrus.Infof("Etcd transaction Response: %v %v", i,
+						responseOp.String())
+				}
+			}
+			if (flags & kvdb.KVModifiedIndex) != 0 {
+				return nil, kvdb.ErrModified
+			} else {
+				return nil, kvdb.ErrValueMismatch
+			}
+		}
+		break
+	}
+
 	kvPair, err := et.Get(kvp.Key)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
- remove code duplication for modified index/value compare and set
- if server timeout is returned during update get value and check if
update went through. If modified index is different than ours and get value
is same as ours, we consider update was successful.

case compare and set if value matches:
this diff works fine if comparison is for value match

case compare and set if index matches:
if two or more updates with the same update value receive server timeout, its unclear how many of those updates went through. since the final update value is same, all of them will conclude that it was their update that went through. since the ultimate value of key is the same - i think this might be ok, after all no update is lost (except index may not be updated), still opening it for debate. 




