### PR TITLE
Etcdv3: For CompareAndSet retry for all etcd server internal errors.

### DIFF
--- a/etcd/v3/kv_etcd.go
+++ b/etcd/v3/kv_etcd.go
@@ -514,24 +514,44 @@ retry:
 			Commit()
 		cancel()
 		if txnErr != nil {
-			if strings.Contains(txnErr.Error(), rpctypes.ErrGRPCTimeout.Error()) {
-				// server timeout
-				kvPair, err := et.Get(kvp.Key)
-				if err != nil {
+			// Check if we need to retry
+			switch txnErr {
+			case context.DeadlineExceeded:
+				logrus.Errorf("[cas %v]: kvdb deadline exceeded error: %v, retry count: %v\n", key, txnErr, i)
+				time.Sleep(ec.DefaultIntervalBetweenRetries)
+			case etcdserver.ErrTimeout:
+				logrus.Errorf("[cas: %v] kvdb error: %v, retry count: %v \n", key, txnErr, i)
+				time.Sleep(ec.DefaultIntervalBetweenRetries)
+			case etcdserver.ErrUnhealthy:
+				logrus.Errorf("[cas: %v] kvdb error: %v, retry count: %v \n", key, txnErr, i)
+				time.Sleep(ec.DefaultIntervalBetweenRetries)
+			default:
+				if err == rpctypes.ErrGRPCEmptyKey {
+					return nil, kvdb.ErrNotFound
+				} else if strings.Contains(txnErr.Error(), rpctypes.ErrGRPCTimeout.Error()) {
+					logrus.Errorf("[cas: %v] kvdb grpc timeout: %v, retry count %v \n", key, txnErr, i)
+					time.Sleep(ec.DefaultIntervalBetweenRetries)
+				} else {
+					// For all other errors return immediately
 					return nil, txnErr
 				}
-				if kvPair.ModifiedIndex == kvp.ModifiedIndex {
-					// update did not succeed, retry
-					if i == (timeoutMaxRetry - 1) {
-						et.FatalCb("Too many server retries for CAS: %v", *kvp)
-					}
-					continue retry
-				} else if bytes.Compare(kvp.Value, kvPair.Value) == 0 {
-					return kvPair, nil
-				}
-				// else someone else updated the value, return error
 			}
-			return nil, txnErr
+
+			// server timeout
+			kvPair, err := et.Get(kvp.Key)
+			if err != nil {
+				return nil, txnErr
+			}
+			if kvPair.ModifiedIndex == kvp.ModifiedIndex {
+				// update did not succeed, retry
+				if i == (timeoutMaxRetry - 1) {
+					et.FatalCb("Too many server retries for CAS: %v", *kvp)
+				}
+				continue retry
+			} else if bytes.Compare(kvp.Value, kvPair.Value) == 0 {
+				return kvPair, nil
+			}
+			// else someone else updated the value, return error
 		}
 		if txnResponse.Succeeded == false {
 			if len(txnResponse.Responses) == 0 {

--- a/etcd/v3/kv_etcd.go
+++ b/etcd/v3/kv_etcd.go
@@ -516,14 +516,8 @@ retry:
 		if txnErr != nil {
 			// Check if we need to retry
 			switch txnErr {
-			case context.DeadlineExceeded:
-				logrus.Errorf("[cas %v]: kvdb deadline exceeded error: %v, retry count: %v\n", key, txnErr, i)
-				time.Sleep(ec.DefaultIntervalBetweenRetries)
-			case etcdserver.ErrTimeout:
-				logrus.Errorf("[cas: %v] kvdb error: %v, retry count: %v \n", key, txnErr, i)
-				time.Sleep(ec.DefaultIntervalBetweenRetries)
-			case etcdserver.ErrUnhealthy:
-				logrus.Errorf("[cas: %v] kvdb error: %v, retry count: %v \n", key, txnErr, i)
+			case context.DeadlineExceeded, etcdserver.ErrTimeout, etcdserver.ErrUnhealthy:
+				logrus.Errorf("[cas %v]: kvdb error: %v, retry count: %v\n", key, txnErr, i)
 				time.Sleep(ec.DefaultIntervalBetweenRetries)
 			default:
 				if err == rpctypes.ErrGRPCEmptyKey {
@@ -552,6 +546,7 @@ retry:
 				return kvPair, nil
 			}
 			// else someone else updated the value, return error
+			return nil, txnErr
 		}
 		if txnResponse.Succeeded == false {
 			if len(txnResponse.Responses) == 0 {


### PR DESCRIPTION
- We already have the logic to retry CAS when there is a grpc timeout.
- Extend it to retry for other error types.