### PR TITLE
Add GetLockTimeout

### DIFF
--- a/kvdb.go
+++ b/kvdb.go
@@ -279,6 +279,8 @@ type Kvdb interface {
 	SetFatalCb(f FatalErrorCB)
 	// SetLockTimeout sets maximum time a lock may be held
 	SetLockTimeout(timeout time.Duration)
+	// GetLockTimeout gets the currently set lock timeout
+	GetLockTimeout() time.Duration
 	// Serialize serializes all the keys under the domain and returns a byte array
 	Serialize() ([]byte, error)
 	// Deserialize deserializes the given byte array into a list of kv pairs

--- a/test/kv.go
+++ b/test/kv.go
@@ -709,6 +709,7 @@ func lock(kv kvdb.Kvdb, t *testing.T) {
 		}
 		kv.SetFatalCb(fatalLockCb)
 		kv.SetLockTimeout(5 * time.Second)
+		assert.Equal(t, kv.GetLockTimeout(), 5*time.Second, "get lock timeout")
 		kvPair2, err = lockMethod("key2")
 		time.Sleep(15 * time.Second)
 		assert.True(t, lockTimedout, "lock timeout not called")


### PR DESCRIPTION
to get the currently set lock timeout. It is already implemented just needed to be added to interface.