### PR TITLE
Etcd v3: CompareAndDelete with retry.

### DIFF
--- a/Dockerfile.kvdb
+++ b/Dockerfile.kvdb
@@ -30,14 +30,13 @@ WORKDIR /go/src/github.com/portworx/kvdb
 
 RUN go get github.com/coreos/etcd
 WORKDIR /go/src/github.com/coreos/etcd
-RUN git checkout v3.2.15
+RUN git checkout v3.3.1
 
 WORKDIR /go/src/github.com/portworx/kvdb
 
 RUN make testdeps
 
-RUN go get github.com/ugorji/go/codec
-WORKDIR /go/src/github.com/ugorji/go/codec
-RUN git checkout faddd6128c66c4708f45fdc007f575f75e592a3c
+WORKDIR /go/src/google.golang.org/grpc
+RUN git checkout v1.7.5
 
 WORKDIR /go/src/github.com/portworx/kvdb

--- a/consul/kv_consul.go
+++ b/consul/kv_consul.go
@@ -429,7 +429,8 @@ func (kv *consulKV) CompareAndDelete(
 		Flags: api.LockFlagValue,
 	}
 
-	if (flags&kvdb.KVModifiedIndex) == 0 && kvp.Value != nil {
+	if (flags & kvdb.KVModifiedIndex) == 0 {
+		// Use value for comparison
 		kvPair, err := kv.Get(kvp.Key)
 		if err != nil {
 			return nil, err
@@ -440,10 +441,9 @@ func (kv *consulKV) CompareAndDelete(
 			return nil, kvdb.ErrValueMismatch
 		}
 		pair.ModifyIndex = kvPair.ModifiedIndex
-	} else if (flags & kvdb.KVModifiedIndex) != 0 {
-		pair.ModifyIndex = kvp.ModifiedIndex
 	} else {
-		pair.ModifyIndex = 0
+		// Use index for comparison
+		pair.ModifyIndex = kvp.ModifiedIndex
 	}
 
 	ok, _, err := kv.client.KV().DeleteCAS(pair, nil)

--- a/consul/kv_consul_test.go
+++ b/consul/kv_consul_test.go
@@ -55,7 +55,9 @@ func Start() error {
 
 	//consul agent -server -client=0.0.0.0  -data-dir /opt/consul/data -bind 0.0.0.0 -syslog -bootstrap-expect 1 -advertise 127.0.0.1
 	cmd = exec.Command("consul", "agent", "-server", "-advertise", "127.0.0.1", "-bind", "0.0.0.0", "-data-dir", "/tmp/consul", "-bootstrap-expect", "1")
-	return cmd.Start()
+	err := cmd.Start()
+	time.Sleep(5 * time.Second)
+	return err
 }
 
 func Stop() error {

--- a/etcd/common/common.go
+++ b/etcd/common/common.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"os"
 	"os/exec"
 	"strconv"
 	"sync"
@@ -206,8 +207,12 @@ func Version(url string, options map[string]string) (string, error) {
 }
 
 func TestStart() error {
-	cmd = exec.Command("etcd", "--advertise-client-urls", "http://127.0.0.1:2379")
-	return cmd.Start()
+	dataDir := "/tmp/etcd"
+	os.RemoveAll(dataDir)
+	cmd = exec.Command("etcd", "--advertise-client-urls", "http://127.0.0.1:2379", "--data-dir", dataDir)
+	err := cmd.Start()
+	time.Sleep(5 * time.Second)
+	return err
 }
 
 func TestStop() error {

--- a/etcd/v3/kv_etcd_test.go
+++ b/etcd/v3/kv_etcd_test.go
@@ -3,8 +3,18 @@ package etcdv3
 import (
 	"testing"
 
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/coreos/etcd/etcdserver"
+	"github.com/coreos/etcd/etcdserver/api/v3rpc/rpctypes"
+	"github.com/portworx/kvdb"
 	"github.com/portworx/kvdb/etcd/common"
 	"github.com/portworx/kvdb/test"
+	"github.com/stretchr/testify/assert"
+
+	"golang.org/x/net/context"
 )
 
 func TestAll(t *testing.T) {
@@ -13,4 +23,47 @@ func TestAll(t *testing.T) {
 	// Uncomment if you have an auth enabled etcd setup. Checkout the test/kv.go for options
 	//test.RunAuth(New, t)
 	test.RunControllerTests(New, t)
+}
+
+func TestIsRetryNeeded(t *testing.T) {
+	fn := "TestIsRetryNeeded"
+	key := "test"
+	retryCount := 1
+
+	// context.DeadlineExceeded
+	retry, err := isRetryNeeded(context.DeadlineExceeded, fn, key, retryCount)
+	assert.EqualError(t, context.DeadlineExceeded, err.Error(), "Unexpcted error")
+	assert.True(t, retry, "Expected a retry")
+
+	// etcdserver.ErrTimeout
+	retry, err = isRetryNeeded(etcdserver.ErrTimeout, fn, key, retryCount)
+	assert.EqualError(t, etcdserver.ErrTimeout, err.Error(), "Unexpcted error")
+	assert.True(t, retry, "Expected a retry")
+
+	// etcdserver.ErrUnhealthy
+	retry, err = isRetryNeeded(etcdserver.ErrUnhealthy, fn, key, retryCount)
+	assert.EqualError(t, etcdserver.ErrUnhealthy, err.Error(), "Unexpcted error")
+	assert.True(t, retry, "Expected a retry")
+
+	// rpctypes.ErrGRPCTimeout
+	retry, err = isRetryNeeded(rpctypes.ErrGRPCTimeout, fn, key, retryCount)
+	assert.EqualError(t, rpctypes.ErrGRPCTimeout, err.Error(), "Unexpcted error")
+	assert.True(t, retry, "Expected a retry")
+
+	// rpctypes.ErrGRPCEmptyKey
+	retry, err = isRetryNeeded(rpctypes.ErrGRPCEmptyKey, fn, key, retryCount)
+	assert.EqualError(t, kvdb.ErrNotFound, err.Error(), "Unexpcted error")
+	assert.False(t, retry, "Expected a retry")
+
+	// etcd v3.2.x uses following grpc error format
+	grpcErr := grpc.Errorf(codes.Unavailable, "desc = some grpc error")
+	retry, err = isRetryNeeded(grpcErr, fn, key, retryCount)
+	assert.EqualError(t, grpcErr, err.Error(), "Unexpcted error")
+	assert.True(t, retry, "Expected a retry")
+
+	// etcd v3.3.x uses the following grpc error format
+	grpcErr = status.New(codes.Unavailable, "desc = some grpc error").Err()
+	retry, err = isRetryNeeded(grpcErr, fn, key, retryCount)
+	assert.EqualError(t, grpcErr, err.Error(), "Unexpcted error")
+	assert.True(t, retry, "Expected a retry")
 }

--- a/test/kv.go
+++ b/test/kv.go
@@ -732,7 +732,8 @@ func lockBetweenRestarts(kv kvdb.Kvdb, t *testing.T, start StartKvdb, stop StopK
 		err = stop()
 		assert.NoError(t, err, "Unable to stop kvdb")
 		// Unlock the key
-		kv.Unlock(kvPair3)
+		go func() { kv.Unlock(kvPair3) }()
+
 		time.Sleep(30 * time.Second)
 
 		fmt.Println("starting kvdb")


### PR DESCRIPTION
- Change the CAD api to retry on a few errors.
- Add ErrStreamDrain/ErrConnClosing to thelist of errors we retry on. These are the errors return etcd 3.3.x and etcd 3.2.x resp when one of the nodes which the client is connected to goes down.
- Clean up few switch statements and collapse them.