### PR TITLE
Return ErrNotFound when deleting non-existing key

### DIFF
--- a/etcd/v3/kv_etcd.go
+++ b/etcd/v3/kv_etcd.go
@@ -361,8 +361,11 @@ func (et *etcdKV) Delete(key string) (*kvdb.KVPair, error) {
 	)
 	cancel()
 	if err == nil {
-		if result.Deleted != 1 {
-			return nil, fmt.Errorf("Incorrect number of keys: %v deleted", key)
+		if result.Deleted == 0 {
+			return nil, kvdb.ErrNotFound
+		} else if result.Deleted > 1 {
+			return nil, fmt.Errorf("Incorrect number of keys: %v deleted, result: %v",
+				key, result)
 		}
 		kvp.Action = kvdb.KVDelete
 		return kvp, nil


### PR DESCRIPTION
There is a race between get/delete in this function, so its difficult to write a UT to test the race. deleteKey test however tests for non-existing key already. 