### PR TITLE
removed logrus info log

### DIFF
--- a/consul/client.go
+++ b/consul/client.go
@@ -180,7 +180,6 @@ func isKeyIndexMismatchErr(err error) bool {
 
 // newKvClient constructs new kvdb.Kvdb given a single end-point to connect to.
 func newKvClient(machine string, p connectionParams) (*api.Config, *api.Client, error) {
-	logrus.Infof("consul: connecting to %v", machine)
 	config := api.DefaultConfig()
 	config.HttpClient = http.DefaultClient
 	config.Address = machine


### PR DESCRIPTION
removed logrus info mesg while connecting to consul server. this was contaminating pxctl output.
Signed-off-by: Saurabh Deoras <saurabh@portworx.com>