### PR TITLE
Etcdv3 CAD: Create a new context for every retry.

### DIFF
--- a/bolt/kv_bolt_Test.go
+++ b/bolt/kv_bolt_Test.go
@@ -123,8 +123,10 @@ func testEnumerateWithSelect(kv kvdb.Kvdb, t *testing.T) {
 	assert.Equal(t, 0, len(output), "Unexpected output")
 }
 
-func Start() error {
-	os.RemoveAll("px.db")
+func Start(removeDir bool) error {
+	if removeDir {
+		os.RemoveAll("px.db")
+	}
 	return nil
 }
 

--- a/consul/kv_consul_test.go
+++ b/consul/kv_consul_test.go
@@ -20,7 +20,7 @@ func TestAll(t *testing.T) {
 	test.Run(New, t, Start, Stop)
 
 	// Run consul specific tests
-	err := Start()
+	err := Start(true)
 	assert.NoError(t, err, "Unable to start kvdb")
 	// Wait for kvdb to start
 	time.Sleep(5 * time.Second)
@@ -49,12 +49,14 @@ func createUsingCAS(kv kvdb.Kvdb, t *testing.T) {
 	_, err = kv.CompareAndSet(kvPair, kvdb.KVModifiedIndex, []byte("some"))
 	assert.Error(t, err, "CompareAndSet did not fail on create")
 }
-func Start() error {
-	if err := os.RemoveAll("/tmp/consul"); err != nil {
-		return err
-	}
-	if err := os.MkdirAll("/tmp/consul", os.ModeDir); err != nil {
-		return err
+func Start(removeDir bool) error {
+	if removeDir {
+		if err := os.RemoveAll("/tmp/consul"); err != nil {
+			return err
+		}
+		if err := os.MkdirAll("/tmp/consul", os.ModeDir); err != nil {
+			return err
+		}
 	}
 
 	//consul agent -server -client=0.0.0.0  -data-dir /opt/consul/data -bind 0.0.0.0 -syslog -bootstrap-expect 1 -advertise 127.0.0.1

--- a/etcd/common/common.go
+++ b/etcd/common/common.go
@@ -216,9 +216,11 @@ func Version(uri string, options map[string]string) (string, error) {
 }
 
 // TestStart starts test
-func TestStart() error {
+func TestStart(removeData bool) error {
 	dataDir := "/tmp/etcd"
-	os.RemoveAll(dataDir)
+	if removeData {
+		os.RemoveAll(dataDir)
+	}
 	cmd = exec.Command("etcd", "--advertise-client-urls", "http://127.0.0.1:2379", "--data-dir", dataDir)
 	err := cmd.Start()
 	time.Sleep(5 * time.Second)

--- a/etcd/v3/kv_etcd.go
+++ b/etcd/v3/kv_etcd.go
@@ -548,13 +548,13 @@ func (et *etcdKV) CompareAndDelete(
 	flags kvdb.KVFlags,
 ) (*kvdb.KVPair, error) {
 	key := et.domain + kvp.Key
-	ctx, cancel := et.Context()
 
 	cmp := e.Compare(e.Value(key), "=", string(kvp.Value))
 	if (flags & kvdb.KVModifiedIndex) != 0 {
 		cmp = e.Compare(e.ModRevision(key), "=", int64(kvp.ModifiedIndex))
 	}
 	for i := 0; i < timeoutMaxRetry; i++ {
+		ctx, cancel := et.Context()
 		txnResponse, txnErr := et.kvClient.Txn(ctx).
 			If(cmp).
 			Then(e.OpDelete(key)).

--- a/mem/kv_mem_test.go
+++ b/mem/kv_mem_test.go
@@ -137,7 +137,7 @@ func testEnumerateWithSelect(kv kvdb.Kvdb, t *testing.T) {
 	assert.Equal(t, 0, len(output), "Unexpected output")
 }
 
-func Start() error {
+func Start(remove bool) error {
 	return nil
 }
 


### PR DESCRIPTION
- Add UTs for CAD/CAS retries