### PR TITLE
Etcdv3 Watch: Handle closing of watch response channel

### DIFF
--- a/etcd/v3/kv_etcd.go
+++ b/etcd/v3/kv_etcd.go
@@ -936,7 +936,7 @@ func (et *etcdKV) watchStart(
 				logrus.Errorf("Watch on key %v cancelled. Error: %v", key,
 					wresp.Err())
 				watchQ.enqueue(key, nil, kvdb.ErrWatchStopped)
-				break
+				return
 			} else {
 				for _, ev := range wresp.Events {
 					var action string
@@ -957,6 +957,8 @@ func (et *etcdKV) watchStart(
 				}
 			}
 		}
+		logrus.Errorf("Watch on key %v closed without a Cancel response.", key)
+		watchQ.enqueue(key, nil, kvdb.ErrWatchStopped)
 	}()
 
 	select {

--- a/etcd/v3/kv_etcd.go
+++ b/etcd/v3/kv_etcd.go
@@ -531,7 +531,7 @@ func (et *etcdKV) CompareAndSet(
 		if txnResponse.Succeeded == false {
 			if len(txnResponse.Responses) == 0 {
 				logrus.Infof("Etcd did not return any transaction responses "+
-					"for key (%v)", kvp.Key)
+					"for key (%v) index (%v)", kvp.Key, kvp.ModifiedIndex)
 			} else {
 				for i, responseOp := range txnResponse.Responses {
 					logrus.Infof("Etcd transaction Response: %v %v", i,
@@ -863,8 +863,9 @@ func (et *etcdKV) refreshLock(
 				if err != nil {
 					et.FatalCb(
 						"Error refreshing lock. [Key %v] [Err: %v]"+
-							" [Current Refresh: %v] [Previous Refresh: %v]",
-						keyString, err, currentRefresh, prevRefresh,
+							" [Current Refresh: %v] [Previous Refresh: %v]"+
+							" [Modified Index: %v]",
+						keyString, err, currentRefresh, prevRefresh, kvPair.ModifiedIndex,
 					)
 					l.Err = err
 					l.Unlock()


### PR DESCRIPTION
- Print the Modified index when Lock or CAS API fails.
- Etcd v3 does not guarantee that it will send a Cancel WatchResponse before stopping the watch.
- Whenever watch is now closed we send a ErrWatchStopped to callback.