### PR TITLE
Etcdv3: Add a lock over etcd's maintenance client.

### DIFF
--- a/etcd/v3/kv_etcd_test.go
+++ b/etcd/v3/kv_etcd_test.go
@@ -5,18 +5,16 @@ import (
 	"testing"
 	"time"
 
-	"google.golang.org/grpc"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
-
 	"github.com/coreos/etcd/etcdserver"
 	"github.com/coreos/etcd/etcdserver/api/v3rpc/rpctypes"
 	"github.com/portworx/kvdb"
 	"github.com/portworx/kvdb/etcd/common"
 	"github.com/portworx/kvdb/test"
 	"github.com/stretchr/testify/assert"
-
 	"golang.org/x/net/context"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 func TestAll(t *testing.T) {


### PR DESCRIPTION
- Take a lock over the maintence client for etcd v3.
- Modified the existing testMemberStatus UT to
  - start 5 node etcd cluster
  - stop 2 nodes
  - spin 16 goroutines and check status of all the 5 members
  - only the 2 stopped nodes should be unhealthy.
- If the lock is removed the testMemberStatus UT will fail.