### PR TITLE
Etcdv3: Maintenance client changes. Add Defragment API.

### DIFF
--- a/etcd/v3/kv_etcd_test.go
+++ b/etcd/v3/kv_etcd_test.go
@@ -45,6 +45,11 @@ func TestIsRetryNeeded(t *testing.T) {
 	assert.EqualError(t, etcdserver.ErrUnhealthy, err.Error(), "Unexpcted error")
 	assert.True(t, retry, "Expected a retry")
 
+	// etcd is sending the error ErrTimeout over grpc instead of the actual ErrGRPCTimeout
+	// hence isRetryNeeded cannot do an actual error comparison
+	retry, err = isRetryNeeded(fmt.Errorf("etcdserver: request timed out"), fn, key, retryCount)
+	assert.True(t, retry, "Expected a retry")
+
 	// rpctypes.ErrGRPCTimeout
 	retry, err = isRetryNeeded(rpctypes.ErrGRPCTimeout, fn, key, retryCount)
 	assert.EqualError(t, rpctypes.ErrGRPCTimeout, err.Error(), "Unexpcted error")

--- a/kvdb.go
+++ b/kvdb.go
@@ -373,4 +373,8 @@ type Controller interface {
 
 	// GetEndpoints returns the kvdb endpoints for the client
 	GetEndpoints() []string
+
+	// Defragment defrags the underlying database for the given endpoint
+	// with a timeout specified in seconds
+	Defragment(endpoint string, timeout int) error
 }

--- a/kvdb_controller_not_supported.go
+++ b/kvdb_controller_not_supported.go
@@ -27,3 +27,7 @@ func (c *controllerNotSupported) SetEndpoints(endpoints []string) error {
 func (c *controllerNotSupported) GetEndpoints() []string {
 	return []string{}
 }
+
+func (c *controllerNotSupported) Defragment(endpoint string, timeout int) error {
+	return ErrNotSupported
+}


### PR DESCRIPTION
- Add a new API to run defragment in Kvdb interface/
- Use MaintenanceContext with no leader for Status APIs.
- Fix a bug in the isRetryNeeded function.
- Do not set the keep alive timeout for maintenance client as it is only used for Status API.