### PR TITLE
Add retry on grpc.ContextDeadlineExceeded. Change RemoveMember API

### DIFF
--- a/etcd/v3/kv_etcd.go
+++ b/etcd/v3/kv_etcd.go
@@ -1455,7 +1455,8 @@ func isRetryNeeded(err error, fn string, key string, retryCount int) (bool, erro
 	case rpctypes.ErrGRPCEmptyKey:
 		return false, kvdb.ErrNotFound
 	default:
-		if grpcStatusErr, ok := status.FromError(err); ok && grpcStatusErr.Code() == codes.Unavailable {
+		if grpcStatusErr, ok := status.FromError(err); ok &&
+			(grpcStatusErr.Code() == codes.Unavailable || grpcStatusErr.Code() == codes.DeadlineExceeded) {
 			// We have got a grpc error wrapped in grpc.Status with Code Unavailable
 			// From grpc golang docs : google.golang.org/grpc/codes/codes.go
 

--- a/etcd/v3/kv_etcd_test.go
+++ b/etcd/v3/kv_etcd_test.go
@@ -76,6 +76,12 @@ func TestIsRetryNeeded(t *testing.T) {
 	retry, err = isRetryNeeded(grpcErr, fn, key, retryCount)
 	assert.EqualError(t, grpcErr, err.Error(), "Unexpcted error")
 	assert.True(t, retry, "Expected a retry")
+
+	// grpc error of ContextDeadlineExceeded
+	gErr := status.New(codes.DeadlineExceeded, "context deadline exceeded").Err()
+	retry, err = isRetryNeeded(gErr, fn, key, retryCount)
+	assert.EqualError(t, gErr, err.Error(), "Unexpcted error")
+	assert.True(t, retry, "Expected a retry")
 }
 
 func TestCasWithRestarts(t *testing.T) {

--- a/kvdb.go
+++ b/kvdb.go
@@ -350,6 +350,7 @@ type MemberInfo struct {
 	Leader     bool
 	DbSize     int64
 	IsHealthy  bool
+	ID         string
 }
 
 // Controller interface provides APIs to manage Kvdb Cluster and Kvdb Clients.
@@ -362,7 +363,7 @@ type Controller interface {
 
 	// RemoveMember removes a member from an existing kvdb cluster
 	// Returns: error if it fails to remove a member
-	RemoveMember(nodeID string) error
+	RemoveMember(nodeName, nodeIP string) error
 
 	// ListMembers enumerates the members of the kvdb cluster
 	// Returns: the nodeID  to memberInfo mappings of all the members

--- a/kvdb_controller_not_supported.go
+++ b/kvdb_controller_not_supported.go
@@ -12,7 +12,7 @@ func (c *controllerNotSupported) AddMember(nodeIP, nodePeerPort, nodeName string
 	return nil, ErrNotSupported
 }
 
-func (c *controllerNotSupported) RemoveMember(nodeID string) error {
+func (c *controllerNotSupported) RemoveMember(nodeID string, nodeIP string) error {
 	return ErrNotSupported
 }
 

--- a/test/kv_controller.go
+++ b/test/kv_controller.go
@@ -96,7 +96,7 @@ func testRemoveMember(kv kvdb.Kvdb, t *testing.T) {
 	// Remove node 1
 	index = 1
 	controllerLog("Removing node 1")
-	err = kv.RemoveMember(names[index])
+	err = kv.RemoveMember(names[index], localhost)
 	require.NoError(t, err, "Error on RemoveMember")
 
 	cmd, _ = cmds[index]


### PR DESCRIPTION
PR comprises of two changes
1. Retry logic
```
Etcd v3 returns both types of errors

1. context.DeadlineExceeded
log line: kvdb error: context deadline exceeded, retry count: 0

2. grpc error code = DeadlineExceeded
log line: cas: get after retry failed with error: rpc error: code = DeadlineExceeded desc = context deadline exceeded
```
2. Add a new field ID in the MemberInfo struct.