### PR TITLE
PWX-6899: preserve err propagation

### DIFF
--- a/consul/client.go
+++ b/consul/client.go
@@ -261,7 +261,7 @@ func (c *consulClientImpl) reconnectIfConnectionError(conn *consulConnection, er
 		if clientErr := c.reconnect(conn); clientErr != nil {
 			return false, clientErr
 		} else {
-			return true, nil
+			return true, err
 		}
 	} else {
 		return false, err


### PR DESCRIPTION
Signed-off-by: Saurabh Deoras <saurabh@portworx.com>

When retrying consul connection, a bool is generated indicating if reconnection is required. however, reconnection won't be tried if loop condition is over. The error was being dropped in such scenario, which needs to be propagated.