### PR TITLE
Improve the kvdb.Snapshot API.

### DIFF
--- a/bolt/kv_bolt.go
+++ b/bolt/kv_bolt.go
@@ -569,7 +569,7 @@ func (kv *boltKV) snapDB() (string, error) {
 	return snapPath, nil
 }
 
-func (kv *boltKV) Snapshot(prefix string) (kvdb.Kvdb, uint64, error) {
+func (kv *boltKV) Snapshot(prefix []string) (kvdb.Kvdb, uint64, error) {
 	kv.mutex.Lock()
 	defer kv.mutex.Unlock()
 

--- a/common/common.go
+++ b/common/common.go
@@ -3,6 +3,7 @@ package common
 import (
 	"container/list"
 	"encoding/json"
+	"strings"
 	"sync"
 	"time"
 
@@ -163,4 +164,25 @@ func (w *watchQueue) Enqueue(key string, kvp *kvdb.KVPair, err error) {
 	w.updates.PushBack(&watchUpdate{key: key, kvp: kvp, err: err})
 	w.cv.Signal()
 	w.m.Unlock()
+}
+
+// PrunePrefixes will return all the top level prefixes from a given list
+// so that any enumerate on these prefixes will not end up returning duplicate keys
+func PrunePrefixes(prefixes []string) []string {
+	prunedPrefixes := []string{}
+	for i := 0; i < len(prefixes); i++ {
+		foundPrefix := false
+		for j := 0; j < len(prefixes); j++ {
+			if i == j {
+				continue
+			}
+			if strings.HasPrefix(prefixes[i], prefixes[j]) {
+				foundPrefix = true
+			}
+		}
+		if !foundPrefix {
+			prunedPrefixes = append(prunedPrefixes, prefixes[i])
+		}
+	}
+	return prunedPrefixes
 }

--- a/common/common_test.go
+++ b/common/common_test.go
@@ -1,0 +1,40 @@
+package common
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPrunePrefixes(t *testing.T) {
+	inputPrefixes := []string{"snapshot/", "snapshot/test", "snapshot1/"}
+	expectedPrefixes := []string{"snapshot/", "snapshot1/"}
+
+	testPrunePrefixes(t, expectedPrefixes, inputPrefixes)
+
+	inputPrefixes = []string{"", "snapshot/test", "snapshot1/"}
+	expectedPrefixes = []string{""}
+
+	testPrunePrefixes(t, expectedPrefixes, inputPrefixes)
+
+	inputPrefixes = []string{"snapshot", "snapshot/test", "snapshot1"}
+	expectedPrefixes = []string{"snapshot"}
+
+	testPrunePrefixes(t, expectedPrefixes, inputPrefixes)
+
+}
+
+func testPrunePrefixes(t *testing.T, expectedPrefixes, inputPrefixes []string) {
+	e := PrunePrefixes(inputPrefixes)
+	assert.Equal(t, len(e), len(expectedPrefixes), "Unexpected no. of prefixes")
+	for i := 0; i < len(e); i++ {
+		found := false
+		for j := 0; j < len(expectedPrefixes); j++ {
+			if e[i] == expectedPrefixes[j] {
+				found = true
+			}
+		}
+		assert.True(t, found, "Expected prefix not found")
+	}
+
+}

--- a/consul/kv_consul.go
+++ b/consul/kv_consul.go
@@ -617,6 +617,11 @@ func (kv *consulKV) TxNew() (kvdb.Tx, error) {
 }
 
 func (kv *consulKV) Snapshot(prefixes []string) (kvdb.Kvdb, uint64, error) {
+	if len(prefixes) == 0 {
+		prefixes = []string{""}
+	} else {
+		prefixes = common.PrunePrefixes(prefixes)
+	}
 	// Create a new bootstrap key : lowest index
 	r := rand.New(rand.NewSource(time.Now().UnixNano())).Int63()
 	bootStrapKeyLow := bootstrap + strconv.FormatInt(r, 10) +

--- a/consul/kv_consul.go
+++ b/consul/kv_consul.go
@@ -616,7 +616,7 @@ func (kv *consulKV) TxNew() (kvdb.Tx, error) {
 	return nil, kvdb.ErrNotSupported
 }
 
-func (kv *consulKV) Snapshot(prefix string) (kvdb.Kvdb, uint64, error) {
+func (kv *consulKV) Snapshot(prefixes []string) (kvdb.Kvdb, uint64, error) {
 	// Create a new bootstrap key : lowest index
 	r := rand.New(rand.NewSource(time.Now().UnixNano())).Int63()
 	bootStrapKeyLow := bootstrap + strconv.FormatInt(r, 10) +
@@ -634,15 +634,22 @@ func (kv *consulKV) Snapshot(prefix string) (kvdb.Kvdb, uint64, error) {
 		RequireConsistent: true,
 	}
 
-	listKey := kv.domain + prefix
-	listKey = stripConsecutiveForwardslash(listKey)
+	var (
+		kvPairs kvdb.KVPairs
+	)
+	for _, prefix := range prefixes {
+		listKey := kv.domain + prefix
+		listKey = stripConsecutiveForwardslash(listKey)
 
-	pairs, _, err := kv.client.List(listKey, options)
-	if err != nil {
-		return nil, 0, err
+		pairs, _, err := kv.client.List(listKey, options)
+		if err != nil {
+			return nil, 0, err
+		}
+
+		kvps := kv.pairToKvs("enumerate", pairs, nil)
+		kvPairs = append(kvPairs, kvps...)
 	}
 
-	kvPairs := kv.pairToKvs("enumerate", pairs, nil)
 	snapDb, err := mem.New(
 		kv.domain,
 		nil,
@@ -689,7 +696,7 @@ func (kv *consulKV) Snapshot(prefix string) (kvdb.Kvdb, uint64, error) {
 			var watchErr error
 			var sendErr error
 			var m *sync.Mutex
-			ok := false
+			var found, ok bool
 
 			if err != nil {
 				if err == kvdb.ErrWatchStopped && watchClosed {
@@ -712,6 +719,17 @@ func (kv *consulKV) Snapshot(prefix string) (kvdb.Kvdb, uint64, error) {
 				watchErr = fmt.Errorf("Failed to get mutex")
 				sendErr = watchErr
 				goto errordone
+			}
+
+			for _, prefix := range prefixes {
+				if strings.HasPrefix(kvp.Key, prefix) {
+					found = true
+					break
+				}
+			}
+
+			if !found {
+				return nil
 			}
 
 			m.Lock()

--- a/consul/kv_consul.go
+++ b/consul/kv_consul.go
@@ -620,6 +620,7 @@ func (kv *consulKV) Snapshot(prefixes []string) (kvdb.Kvdb, uint64, error) {
 	if len(prefixes) == 0 {
 		prefixes = []string{""}
 	} else {
+		prefixes = append(prefixes, bootstrap)
 		prefixes = common.PrunePrefixes(prefixes)
 	}
 	// Create a new bootstrap key : lowest index

--- a/etcd/v3/kv_etcd.go
+++ b/etcd/v3/kv_etcd.go
@@ -1000,6 +1000,7 @@ func (et *etcdKV) Snapshot(prefixes []string) (kvdb.Kvdb, uint64, error) {
 	if len(prefixes) == 0 {
 		prefixes = []string{""}
 	} else {
+		prefixes = append(prefixes, ec.Bootstrap)
 		prefixes = common.PrunePrefixes(prefixes)
 	}
 	// Create a new bootstrap key
@@ -1046,10 +1047,10 @@ func (et *etcdKV) Snapshot(prefixes []string) (kvdb.Kvdb, uint64, error) {
 			goto errordone
 		}
 
+		m.Lock()
+		defer m.Unlock()
 		for _, configuredPrefix := range prefixes {
 			if strings.HasPrefix(kvp.Key, configuredPrefix) {
-				m.Lock()
-				defer m.Unlock()
 				updates = append(updates, kvp)
 				if highestKvdbIndex > 0 && kvp.ModifiedIndex >= highestKvdbIndex {
 					// Done applying changes.
@@ -1141,6 +1142,9 @@ func (et *etcdKV) Snapshot(prefixes []string) (kvdb.Kvdb, uint64, error) {
 		}
 	}
 
+	// take the lock before we Put a key so that
+	// the highestKvdbIndex will be set before the watch callback is invoked
+	mutex.Lock()
 	// Create bootrap key : highest index
 	bootStrapKeyHigh := ec.Bootstrap + strconv.FormatInt(r, 10) +
 		strconv.FormatInt(time.Now().UnixNano(), 10)
@@ -1150,8 +1154,6 @@ func (et *etcdKV) Snapshot(prefixes []string) (kvdb.Kvdb, uint64, error) {
 			"err: %v", bootStrapKeyHigh, err)
 	}
 
-	mutex.Lock()
-	// not sure if we need a lock, but couldnt find any doc which says its ok
 	highestKvdbIndex = kvPair.ModifiedIndex
 	mutex.Unlock()
 

--- a/etcd/v3/kv_etcd.go
+++ b/etcd/v3/kv_etcd.go
@@ -996,13 +996,15 @@ func (et *etcdKV) watchStart(
 	}
 }
 
-func (et *etcdKV) Snapshot(prefix string) (kvdb.Kvdb, uint64, error) {
+func (et *etcdKV) Snapshot(prefixes []string) (kvdb.Kvdb, uint64, error) {
 	// Create a new bootstrap key
 	var updates []*kvdb.KVPair
 	watchClosed := false
 	var lowestKvdbIndex, highestKvdbIndex uint64
 	done := make(chan error)
 	mutex := &sync.Mutex{}
+
+	// watch callback function
 	cb := func(
 		prefix string,
 		opaque interface{},
@@ -1012,6 +1014,7 @@ func (et *etcdKV) Snapshot(prefix string) (kvdb.Kvdb, uint64, error) {
 		var watchErr error
 		var sendErr error
 		var m *sync.Mutex
+		var prefixMatch bool
 		ok := false
 
 		if err != nil {
@@ -1039,22 +1042,75 @@ func (et *etcdKV) Snapshot(prefix string) (kvdb.Kvdb, uint64, error) {
 			goto errordone
 		}
 
-		m.Lock()
-		defer m.Unlock()
-		updates = append(updates, kvp)
-		if highestKvdbIndex > 0 && kvp.ModifiedIndex >= highestKvdbIndex {
-			// Done applying changes.
-			logrus.Infof("Snapshot complete")
-			watchClosed = true
-			watchErr = fmt.Errorf("done")
-			sendErr = nil
-			goto errordone
+		for _, configuredPrefix := range prefixes {
+			if strings.HasPrefix(kvp.Key, configuredPrefix) {
+				prefixMatch = true
+				break
+			}
+		}
+		if prefixMatch {
+			m.Lock()
+			defer m.Unlock()
+			updates = append(updates, kvp)
+			if highestKvdbIndex > 0 && kvp.ModifiedIndex >= highestKvdbIndex {
+				// Done applying changes.
+				logrus.Infof("Snapshot complete")
+				watchClosed = true
+				watchErr = fmt.Errorf("done")
+				sendErr = nil
+				goto errordone
+			}
 		}
 
 		return nil
 	errordone:
 		done <- sendErr
 		return watchErr
+	}
+
+	var (
+		kvPairs kvdb.KVPairs
+		err     error
+	)
+	// enumerate prefix function
+	enumeratePrefix := func(snapDb kvdb.Kvdb, prefix string) error {
+		kvPairs, err = et.Enumerate(prefix)
+		if err != nil {
+			return fmt.Errorf("Failed to enumerate %v: err: %v", prefix,
+				err)
+		}
+
+		for i := 0; i < len(kvPairs); i++ {
+			kvPair := kvPairs[i]
+			if len(kvPair.Value) > 0 {
+				// Only create a leaf node
+				_, err := snapDb.SnapPut(kvPair)
+				if err != nil {
+					return fmt.Errorf("Failed creating snap: %v", err)
+				}
+			} else {
+				newKvPairs, err := et.Enumerate(kvPair.Key)
+				if err != nil {
+					return fmt.Errorf("Failed to get child keys: %v", err)
+				}
+				if len(newKvPairs) == 0 {
+					// empty value for this key
+					_, err := snapDb.SnapPut(kvPair)
+					if err != nil {
+						return fmt.Errorf("Failed creating snap: %v", err)
+					}
+				} else if len(newKvPairs) == 1 {
+					// empty value for this key
+					_, err := snapDb.SnapPut(newKvPairs[0])
+					if err != nil {
+						return fmt.Errorf("Failed creating snap: %v", err)
+					}
+				} else {
+					kvPairs = append(kvPairs, newKvPairs...)
+				}
+			}
+		}
+		return nil
 	}
 
 	if err := et.WatchTree("", 0, mutex, cb); err != nil {
@@ -1071,11 +1127,6 @@ func (et *etcdKV) Snapshot(prefix string) (kvdb.Kvdb, uint64, error) {
 	}
 	lowestKvdbIndex = kvPair.ModifiedIndex
 
-	kvPairs, err := et.Enumerate(prefix)
-	if err != nil {
-		return nil, 0, fmt.Errorf("Failed to enumerate %v: err: %v", prefix,
-			err)
-	}
 	snapDb, err := mem.New(
 		et.domain,
 		nil,
@@ -1086,34 +1137,10 @@ func (et *etcdKV) Snapshot(prefix string) (kvdb.Kvdb, uint64, error) {
 		return nil, 0, fmt.Errorf("Failed to create in-mem kv store: %v", err)
 	}
 
-	for i := 0; i < len(kvPairs); i++ {
-		kvPair := kvPairs[i]
-		if len(kvPair.Value) > 0 {
-			// Only create a leaf node
-			_, err := snapDb.SnapPut(kvPair)
-			if err != nil {
-				return nil, 0, fmt.Errorf("Failed creating snap: %v", err)
-			}
-		} else {
-			newKvPairs, err := et.Enumerate(kvPair.Key)
-			if err != nil {
-				return nil, 0, fmt.Errorf("Failed to get child keys: %v", err)
-			}
-			if len(newKvPairs) == 0 {
-				// empty value for this key
-				_, err := snapDb.SnapPut(kvPair)
-				if err != nil {
-					return nil, 0, fmt.Errorf("Failed creating snap: %v", err)
-				}
-			} else if len(newKvPairs) == 1 {
-				// empty value for this key
-				_, err := snapDb.SnapPut(newKvPairs[0])
-				if err != nil {
-					return nil, 0, fmt.Errorf("Failed creating snap: %v", err)
-				}
-			} else {
-				kvPairs = append(kvPairs, newKvPairs...)
-			}
+	// Enumerate all configured prefixes
+	for _, prefix := range prefixes {
+		if err := enumeratePrefix(snapDb, prefix); err != nil {
+			return nil, 0, err
 		}
 	}
 

--- a/kvdb.go
+++ b/kvdb.go
@@ -256,8 +256,8 @@ type Kvdb interface {
 	// WatchTree is the same as WatchKey except that watchCB is triggered
 	// for updates on all keys that share the prefix.
 	WatchTree(prefix string, waitIndex uint64, opaque interface{}, watchCB WatchCB) error
-	// Snapshot returns a kvdb snapshot and its version.
-	Snapshot(prefix string) (Kvdb, uint64, error)
+	// Snapshot returns a kvdb snapshot of the provided list of prefixes and the last updated index.
+	Snapshot(prefixes []string) (Kvdb, uint64, error)
 	// SnapPut records the key value pair including the index.
 	SnapPut(kvp *KVPair) (*KVPair, error)
 	// Lock specfied key and associate a lockerID with it, probably to identify

--- a/kvdb.go
+++ b/kvdb.go
@@ -256,7 +256,7 @@ type Kvdb interface {
 	// WatchTree is the same as WatchKey except that watchCB is triggered
 	// for updates on all keys that share the prefix.
 	WatchTree(prefix string, waitIndex uint64, opaque interface{}, watchCB WatchCB) error
-	// Snapshot returns a kvdb snapshot of the provided list of prefixes and the last updated index.
+	// Snapshot returns a kvdb snapshot of the provided list of prefixes and the last updated index. If no prefixes are provided, then the whole kvdb tree is snapshotted and could be potentially an expensive operation
 	Snapshot(prefixes []string) (Kvdb, uint64, error)
 	// SnapPut records the key value pair including the index.
 	SnapPut(kvp *KVPair) (*KVPair, error)

--- a/mem/kv_mem.go
+++ b/mem/kv_mem.go
@@ -287,8 +287,9 @@ func (kv *memKV) Snapshot(prefixes []string) (kvdb.Kvdb, uint64, error) {
 		if strings.Contains(key, "/_") {
 			continue
 		}
-		found := true
+		found := false
 		for _, prefix := range prefixes {
+			prefix = kv.domain + prefix
 			if strings.HasPrefix(key, prefix) {
 				found = true
 				break

--- a/mem/kv_mem.go
+++ b/mem/kv_mem.go
@@ -275,7 +275,7 @@ func (kv *memKV) Get(key string) (*kvdb.KVPair, error) {
 	return v.copy(), nil
 }
 
-func (kv *memKV) Snapshot(prefix string) (kvdb.Kvdb, uint64, error) {
+func (kv *memKV) Snapshot(prefixes []string) (kvdb.Kvdb, uint64, error) {
 	kv.mutex.Lock()
 	defer kv.mutex.Unlock()
 	_, err := kv.put(bootstrapKey, time.Now().UnixNano(), 0)
@@ -284,7 +284,17 @@ func (kv *memKV) Snapshot(prefix string) (kvdb.Kvdb, uint64, error) {
 	}
 	data := make(map[string]*memKVPair)
 	for key, value := range kv.m {
-		if !strings.HasPrefix(key, prefix) && strings.Contains(key, "/_") {
+		if strings.Contains(key, "/_") {
+			continue
+		}
+		found := true
+		for _, prefix := range prefixes {
+			if strings.HasPrefix(key, prefix) {
+				found = true
+				break
+			}
+		}
+		if !found {
 			continue
 		}
 		snap := &memKVPair{}

--- a/mem/kv_mem.go
+++ b/mem/kv_mem.go
@@ -307,9 +307,11 @@ func (kv *memKV) Snapshot(prefixes []string) (kvdb.Kvdb, uint64, error) {
 	}
 	highestKvPair, _ := kv.delete(bootstrapKey)
 	// Snapshot only data, watches are not copied.
-	return &memKV{
-		m:      data,
-		domain: kv.domain,
+	return &snapMem{
+		&memKV{
+			m:      data,
+			domain: kv.domain,
+		},
 	}, highestKvPair.ModifiedIndex, nil
 }
 

--- a/test/kv.go
+++ b/test/kv.go
@@ -527,9 +527,18 @@ func concurrentEnum(kv kvdb.Kvdb, t *testing.T) {
 
 func snapshot(kv kvdb.Kvdb, t *testing.T) {
 	fmt.Println("snapshot")
+
 	prefix := "snapshot/"
 	kv.DeleteTree(prefix)
 	defer kv.DeleteTree(prefix)
+
+	prefix2 := "snapshot2/"
+	kv.DeleteTree(prefix2)
+	defer kv.DeleteTree(prefix2)
+
+	ignorePrefix := "ignoreSnapshot/"
+	kv.DeleteTree(ignorePrefix)
+	defer kv.DeleteTree(ignorePrefix)
 
 	preSnapData := make(map[string]string)
 	preSnapDataVersion := make(map[string]uint64)
@@ -548,7 +557,12 @@ func snapshot(kv kvdb.Kvdb, t *testing.T) {
 		versionMap map[string]uint64, isDelete bool) {
 		for i := 0; i < count; i++ {
 			suffix := strconv.Itoa(i)
-			inputKey := prefix + key + suffix
+			var inputKey string
+			if i%2 == 0 {
+				inputKey = prefix + key + suffix
+			} else {
+				inputKey = prefix2 + key + suffix
+			}
 			inputValue := v
 			if i == 0 {
 				emptyKeyName = inputKey
@@ -568,6 +582,19 @@ func snapshot(kv kvdb.Kvdb, t *testing.T) {
 				assert.NoError(t, err, "Unexpected error on Delete")
 			}
 
+			// update ops on keys which need to be ignore
+			inputKey = ignorePrefix + key + suffix
+			_, err = kv.Put(inputKey, []byte(inputValue), 0)
+			assert.NoError(t, err, "Unexpected error on Put")
+
+			deleteKey = ignorePrefix + keyd + suffix
+			if !isDelete {
+				_, err := kv.Put(deleteKey, []byte(valued), 0)
+				assert.NoError(t, err, "Unexpected error on Put")
+			} else {
+				_, err := kv.Delete(deleteKey)
+				assert.NoError(t, err, "Unexpected error on Delete")
+			}
 		}
 		doneUpdate <- true
 	}
@@ -578,12 +605,19 @@ func snapshot(kv kvdb.Kvdb, t *testing.T) {
 	go updateFn(count, newValue, inputData, inputDataVersion, true)
 	time.Sleep(20 * time.Millisecond)
 
-	snap, snapVersion, err := kv.Snapshot(prefix)
+	snap, snapVersion, err := kv.Snapshot([]string{prefix, prefix2})
 	assert.NoError(t, err, "Unexpected error on Snapshot")
 	<-doneUpdate
 
-	kvPairs, err := snap.Enumerate(prefix)
+	// Enumerate on prefix 1
+	kvps, err := snap.Enumerate(prefix)
 	assert.NoError(t, err, "Unexpected error on Enumerate")
+
+	// Enumerate on prefix 2
+	kvps2, err := snap.Enumerate(prefix2)
+	assert.NoError(t, err, "Unexpected error on Enumerate")
+
+	kvPairs := append(kvps, kvps2...)
 
 	processedKeys := 0
 	for i := range kvPairs {
@@ -626,6 +660,9 @@ func snapshot(kv kvdb.Kvdb, t *testing.T) {
 		"Expecting %d keys under %s got: %d, kv: %v",
 		processedKeys, prefix, len(kvPairs), kvPairs)
 
+	// Check there are no keys under the ignored prefix
+	kvPairs, err = snap.Enumerate(ignorePrefix)
+	assert.Equal(t, 0, len(kvPairs), "Expected 0 pairs to be returned under the ignored prefix")
 }
 
 func getLockMethods(kv kvdb.Kvdb) []func(string) (*kvdb.KVPair, error) {

--- a/test/kv.go
+++ b/test/kv.go
@@ -536,6 +536,8 @@ func snapshot(kv kvdb.Kvdb, t *testing.T) {
 	kv.DeleteTree(prefix2)
 	defer kv.DeleteTree(prefix2)
 
+	prefix3 := "snapshot2/subtree/"
+
 	ignorePrefix := "ignoreSnapshot/"
 	kv.DeleteTree(ignorePrefix)
 	defer kv.DeleteTree(ignorePrefix)
@@ -558,8 +560,10 @@ func snapshot(kv kvdb.Kvdb, t *testing.T) {
 		for i := 0; i < count; i++ {
 			suffix := strconv.Itoa(i)
 			var inputKey string
-			if i%2 == 0 {
+			if i%3 == 0 {
 				inputKey = prefix + key + suffix
+			} else if i%3 == 1 {
+				inputKey = prefix3 + key + suffix
 			} else {
 				inputKey = prefix2 + key + suffix
 			}
@@ -605,7 +609,7 @@ func snapshot(kv kvdb.Kvdb, t *testing.T) {
 	go updateFn(count, newValue, inputData, inputDataVersion, true)
 	time.Sleep(20 * time.Millisecond)
 
-	snap, snapVersion, err := kv.Snapshot([]string{prefix, prefix2})
+	snap, snapVersion, err := kv.Snapshot([]string{prefix, prefix2, prefix3})
 	assert.NoError(t, err, "Unexpected error on Snapshot")
 	<-doneUpdate
 


### PR DESCRIPTION
- Instead of enumerating the whole kvdb tree, now the Snapshot API takes in a list
  of prefixes. A snapshot is taken only on those prefixes.
- This helps in reducing long range queries which etcd does not like.
- If etcd is unstable or running on a slow disk, enumerating the whole tree can sometimes return errors/timeouts
- This will reduce the time taken for the Snapshot API to complete as well.
- Modified the UT to
  - test the snapshot api on multiple prefixes
  - at the same time do updates to a prefix which is not snapshotted