### PR TITLE
Add consistent boolean to Snapshot API.

### DIFF
--- a/bolt/kv_bolt.go
+++ b/bolt/kv_bolt.go
@@ -569,7 +569,7 @@ func (kv *boltKV) snapDB() (string, error) {
 	return snapPath, nil
 }
 
-func (kv *boltKV) Snapshot(prefix []string) (kvdb.Kvdb, uint64, error) {
+func (kv *boltKV) Snapshot(prefix []string, consistent bool) (kvdb.Kvdb, uint64, error) {
 	kv.mutex.Lock()
 	defer kv.mutex.Unlock()
 

--- a/consul/kv_consul.go
+++ b/consul/kv_consul.go
@@ -616,13 +616,14 @@ func (kv *consulKV) TxNew() (kvdb.Tx, error) {
 	return nil, kvdb.ErrNotSupported
 }
 
-func (kv *consulKV) Snapshot(prefixes []string) (kvdb.Kvdb, uint64, error) {
+func (kv *consulKV) Snapshot(prefixes []string, consistent bool) (kvdb.Kvdb, uint64, error) {
 	if len(prefixes) == 0 {
 		prefixes = []string{""}
 	} else {
 		prefixes = append(prefixes, bootstrap)
 		prefixes = common.PrunePrefixes(prefixes)
 	}
+
 	// Create a new bootstrap key : lowest index
 	r := rand.New(rand.NewSource(time.Now().UnixNano())).Int63()
 	bootStrapKeyLow := bootstrap + strconv.FormatInt(r, 10) +
@@ -671,6 +672,12 @@ func (kv *consulKV) Snapshot(prefixes []string) (kvdb.Kvdb, uint64, error) {
 		if err != nil {
 			return nil, 0, fmt.Errorf("Failed creating snap: %v", err)
 		}
+	}
+
+	if !consistent {
+		// A consistent snapshot is not required
+		// return all the enumerated keys
+		return snapDb, 0, nil
 	}
 
 	// Create bootrap key : highest index

--- a/kvdb.go
+++ b/kvdb.go
@@ -258,8 +258,11 @@ type Kvdb interface {
 	// WatchTree is the same as WatchKey except that watchCB is triggered
 	// for updates on all keys that share the prefix.
 	WatchTree(prefix string, waitIndex uint64, opaque interface{}, watchCB WatchCB) error
-	// Snapshot returns a kvdb snapshot of the provided list of prefixes and the last updated index. If no prefixes are provided, then the whole kvdb tree is snapshotted and could be potentially an expensive operation
-	Snapshot(prefixes []string) (Kvdb, uint64, error)
+	// Snapshot returns a kvdb snapshot of the provided list of prefixes and the last updated index.
+	// If no prefixes are provided, then the whole kvdb tree is snapshotted and could be potentially an expensive operation
+	// If consistent is true, then snapshot is going to return all the updates happening during the snapshot operation and the last
+	// updated index from the snapshot
+	Snapshot(prefixes []string, consistent bool) (Kvdb, uint64, error)
 	// SnapPut records the key value pair including the index.
 	SnapPut(kvp *KVPair) (*KVPair, error)
 	// Lock specfied key and associate a lockerID with it, probably to identify

--- a/mem/kv_mem.go
+++ b/mem/kv_mem.go
@@ -275,7 +275,7 @@ func (kv *memKV) Get(key string) (*kvdb.KVPair, error) {
 	return v.copy(), nil
 }
 
-func (kv *memKV) Snapshot(prefixes []string) (kvdb.Kvdb, uint64, error) {
+func (kv *memKV) Snapshot(prefixes []string, consistent bool) (kvdb.Kvdb, uint64, error) {
 	kv.mutex.Lock()
 	defer kv.mutex.Unlock()
 	_, err := kv.put(bootstrapKey, time.Now().UnixNano(), 0)

--- a/test/kv.go
+++ b/test/kv.go
@@ -635,7 +635,7 @@ func snapshot(kv kvdb.Kvdb, t *testing.T) {
 	go updateFn(count, newValue, inputData, inputDataVersion, true)
 	time.Sleep(20 * time.Millisecond)
 
-	snap, snapVersion, err := kv.Snapshot([]string{prefix, prefix2, prefix3})
+	snap, snapVersion, err := kv.Snapshot([]string{prefix, prefix2, prefix3}, true)
 	assert.NoError(t, err, "Unexpected error on Snapshot")
 	<-doneUpdate
 

--- a/zookeeper/kv_zookeeper.go
+++ b/zookeeper/kv_zookeeper.go
@@ -425,7 +425,7 @@ func (z *zookeeperKV) WatchTree(
 	return kvdb.ErrNotSupported
 }
 
-func (z *zookeeperKV) Snapshot(prefixes []string) (kvdb.Kvdb, uint64, error) {
+func (z *zookeeperKV) Snapshot(prefixes []string, consistent bool) (kvdb.Kvdb, uint64, error) {
 	return nil, 0, kvdb.ErrNotSupported
 }
 


### PR DESCRIPTION
- If the consistent flag is not true, then a Watch is not started in the Snapshot API.