### PR TITLE
RemoveMember: Retry remove member in case of a failure

### DIFF
--- a/etcd/v3/kv_etcd.go
+++ b/etcd/v3/kv_etcd.go
@@ -1374,6 +1374,7 @@ func (et *etcdKV) RemoveMember(
 	nodeName string,
 	nodeIP string,
 ) error {
+	fn := "RemoveMember"
 	ctx, cancel := et.MaintenanceContextWithLeader()
 	memberListResponse, err := et.kvClient.MemberList(ctx)
 	cancel()
@@ -1403,11 +1404,31 @@ func (et *etcdKV) RemoveMember(
 		}
 	}
 	et.kvClient.SetEndpoints(newClientUrls...)
-	ctx, cancel = et.MaintenanceContextWithLeader()
-	_, err = et.kvClient.MemberRemove(ctx, removeMemberID)
-	cancel()
-	if err != nil {
-		return err
+	removeMemberRetries := 5
+	for i := 0; i < removeMemberRetries; i++ {
+		ctx, cancel = et.MaintenanceContextWithLeader()
+		_, err := et.kvClient.MemberRemove(ctx, removeMemberID)
+		cancel()
+
+		if err != nil {
+			// Check if the error is member not found
+			etcdErr, ok := err.(rpctypes.EtcdError)
+			if ok && etcdErr == rpctypes.ErrMemberNotFound {
+				return nil
+			}
+			// Check if we need to retry
+			retry, err := isRetryNeeded(err, fn, nodeName, i)
+			if !retry {
+				// For all others return immediately
+				return err
+			}
+			if i == (removeMemberRetries - 1) {
+				return fmt.Errorf("Too many retries for RemoveMember: %v %v", nodeName, nodeIP)
+			}
+			time.Sleep(2 * time.Second)
+			continue
+		}
+		break
 	}
 	return nil
 }

--- a/test/kv_controller.go
+++ b/test/kv_controller.go
@@ -108,6 +108,12 @@ func testRemoveMember(kv kvdb.Kvdb, t *testing.T) {
 	list, err = kv.ListMembers()
 	require.NoError(t, err, "Error on ListMembers")
 	require.Equal(t, 2, len(list), "List returned different length of cluster")
+
+	// Remove an already removed node
+	index = 1
+	controllerLog("Removing node 1")
+	err = kv.RemoveMember(names[index], localhost)
+	require.NoError(t, err, "Error on RemoveMember")
 }
 
 func testReAdd(kv kvdb.Kvdb, t *testing.T) {


### PR DESCRIPTION
- Retry RemoveMember operation if it fails on unknown errors.
- Check if the error returned is not ErrMemberNotFound.
- Return nil for members that do not exist.