### PR TITLE
Unlock on conn error

### DIFF
--- a/consul/client.go
+++ b/consul/client.go
@@ -25,6 +25,8 @@ const (
 	keyIndexMismatch = "Key Index mismatch"
 	// nameResolutionError indicates no host found, can be temporary
 	nameResolutionError = "no such host"
+	// connReset connection reset by peer
+	connReset = "connection reset by peer"
 )
 
 // clientConsul defines methods that a px based consul client should satisfy.
@@ -169,7 +171,8 @@ func isConsulErrNeedingRetry(err error) bool {
 	return strings.Contains(err.Error(), httpError) ||
 		strings.Contains(err.Error(), eofError) ||
 		strings.Contains(err.Error(), connRefused) ||
-		strings.Contains(err.Error(), nameResolutionError)
+		strings.Contains(err.Error(), nameResolutionError) ||
+		strings.Contains(err.Error(), connReset)
 }
 
 // isKeyIndexMismatchErr returns true if error contains key index mismatch substring

--- a/consul/kv_consul.go
+++ b/consul/kv_consul.go
@@ -600,8 +600,10 @@ func (kv *consulKV) Unlock(kvp *kvdb.KVPair) error {
 		return fmt.Errorf("Invalid lock structure for key: %v", string(kvp.Key))
 	}
 	_, err := kv.Delete(kvp.Key)
-	if err == nil {
+
+	if err == nil || isConsulErrNeedingRetry(err) {
 		_ = l.lock.Unlock()
+		// stop refreshing the lock, this will automatically release the lock
 		if l.doneCh != nil {
 			close(l.doneCh)
 		}

--- a/test/kv.go
+++ b/test/kv.go
@@ -817,13 +817,13 @@ func lockBetweenRestarts(kv kvdb.Kvdb, t *testing.T, start StartKvdb, stop StopK
 		// Try to take the lock again
 		// We need this test for consul to check if LockDelay is not set
 		fmt.Println("lock before restarting kvdb")
-		kvPair3, err := lockMethod("key3")
+		kvPairBeforeRestart, err := lockMethod("key3")
 		assert.NoError(t, err, "Unable to take a lock")
 		fmt.Println("stopping kvdb")
 		err = stop()
 		assert.NoError(t, err, "Unable to stop kvdb")
 		// Unlock the key
-		go func() { kv.Unlock(kvPair3) }()
+		go func() { kv.Unlock(kvPairBeforeRestart) }()
 
 		time.Sleep(30 * time.Second)
 
@@ -833,12 +833,13 @@ func lockBetweenRestarts(kv kvdb.Kvdb, t *testing.T, start StartKvdb, stop StopK
 		time.Sleep(40 * time.Second)
 
 		lockChan := make(chan int)
+		var kvPair3 *kvdb.KVPair
 		go func() {
 			kvPair3, err = lockMethod("key3")
 			lockChan <- 1
 		}()
 		select {
-		case <-time.After(5 * time.Second):
+		case <-time.After(20 * time.Second):
 			assert.Fail(t, "Unable to take a lock whose session is expired")
 		case <-lockChan:
 		}


### PR DESCRIPTION
If we get connection errors when trying to unlock, stopping the refresh routine should be enough since the locks are created with ttl.  