### PR TITLE
kvdb quorum check

### DIFF
--- a/Dockerfile.kvdb
+++ b/Dockerfile.kvdb
@@ -20,7 +20,7 @@ RUN curl -s -L https://dl.google.com/go/go1.10.7.linux-amd64.tar.gz | tar -C /us
   mkdir -p /tmp/test-etcd && tar xzvf /tmp/etcd-v3.2.15-linux-amd64.tar.gz -C /tmp/test-etcd --strip-components=1 && cp /tmp/test-etcd/etcd /usr/local/bin  && \
   curl -s -L https://releases.hashicorp.com/consul/1.0.0/consul_1.0.0_linux_amd64.zip -o /tmp/consul.zip && \
   mkdir -p /tmp/test-consul && unzip /tmp/consul.zip -d /tmp/test-consul && cp /tmp/test-consul/consul /usr/local/bin/ && \
-  curl -s -L https://apache.org/dist/zookeeper/zookeeper-3.4.13/zookeeper-3.4.13.tar.gz -o /tmp/zookeeper-3.4.13.tar.gz && \
+  curl -s -L https://archive.apache.org/dist/zookeeper/zookeeper-3.4.13/zookeeper-3.4.13.tar.gz -o /tmp/zookeeper-3.4.13.tar.gz && \
   mkdir -p /tmp/test-zookeeper && tar -xvf /tmp/zookeeper-3.4.13.tar.gz -C /tmp/test-zookeeper --strip-components=1 && mkdir -p /data/zookeeper
 
 ENV PATH /usr/local/go/bin:/usr/local/bin:/usr/local/sbin:/usr/bin:/usr/sbin:/bin:/sbin

--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,7 @@ errcheck:
 		github.com/portworx/kvdb/common \
 		github.com/portworx/kvdb/consul \
 		github.com/portworx/kvdb/mem \
+		github.com/portworx/kvdb/wrappers \
 		github.com/portworx/kvdb/zookeeper
 
 pretest: deps errcheck lint vet

--- a/common/common.go
+++ b/common/common.go
@@ -105,6 +105,14 @@ func (b *BaseKvdb) DeserializeAll(out []byte) (kvdb.KVPairs, error) {
 	return kvps, nil
 }
 
+func (b *BaseKvdb) SetQuorumState(state kvdb.KvdbQuorumState) {
+	// no-op
+}
+
+func (b *BaseKvdb) QuorumState() kvdb.KvdbQuorumState {
+	return kvdb.KvdbInQuorum
+}
+
 // watchUpdate refers to an update to this kvdb
 type watchUpdate struct {
 	// key is the key that was updated

--- a/common/common.go
+++ b/common/common.go
@@ -84,7 +84,7 @@ func (b *BaseKvdb) LockTimedout(key string) {
 
 // lockTimedout function is invoked if lock is held past configured timeout.
 func (b *BaseKvdb) lockTimedout(key string) {
-	b.FatalCb("Lock %s hold timeout triggered", key)
+	b.FatalCb(kvdb.ErrLockHoldTimeoutTriggered, "Lock %s hold timeout triggered", key)
 }
 
 // SerializeAll Serializes all key value pairs to a byte array.

--- a/consul/client.go
+++ b/consul/client.go
@@ -25,6 +25,8 @@ const (
 	keyIndexMismatch = "Key Index mismatch"
 	// nameResolutionError indicates no host found, can be temporary
 	nameResolutionError = "no such host"
+	// connReset connection reset by peer
+	connReset = "connection reset by peer"
 )
 
 // clientConsul defines methods that a px based consul client should satisfy.
@@ -169,7 +171,8 @@ func isConsulErrNeedingRetry(err error) bool {
 	return strings.Contains(err.Error(), httpError) ||
 		strings.Contains(err.Error(), eofError) ||
 		strings.Contains(err.Error(), connRefused) ||
-		strings.Contains(err.Error(), nameResolutionError)
+		strings.Contains(err.Error(), nameResolutionError) ||
+		strings.Contains(err.Error(), connReset)
 }
 
 // isKeyIndexMismatchErr returns true if error contains key index mismatch substring

--- a/consul/kv_consul.go
+++ b/consul/kv_consul.go
@@ -600,8 +600,10 @@ func (kv *consulKV) Unlock(kvp *kvdb.KVPair) error {
 		return fmt.Errorf("Invalid lock structure for key: %v", string(kvp.Key))
 	}
 	_, err := kv.Delete(kvp.Key)
-	if err == nil {
+
+	if err == nil || isConsulErrNeedingRetry(err) {
 		_ = l.lock.Unlock()
+		// stop refreshing the lock, this will automatically release the lock
 		if l.doneCh != nil {
 			close(l.doneCh)
 		}

--- a/etcd/v2/kv_etcd.go
+++ b/etcd/v2/kv_etcd.go
@@ -585,7 +585,7 @@ func (kv *etcdKV) refreshLock(
 				)
 				currentRefresh = time.Now()
 				if err != nil {
-					kv.FatalCb(
+					kv.FatalCb(kvdb.ErrLockRefreshFailed,
 						"Error refreshing lock. [Key %v] [Err: %v] [Acquisition Time: %v]"+
 							" [Current Refresh: %v] [Previous Refresh: %v]",
 						keyString, err, l.AcquisitionTime, currentRefresh, prevRefresh,

--- a/etcd/v3/kv_etcd.go
+++ b/etcd/v3/kv_etcd.go
@@ -884,9 +884,6 @@ func (et *etcdKV) refreshLock(
 				)
 				currentRefresh = time.Now()
 				if err != nil {
-					logrus.Infof("XXX   Error refreshing lock. [Tag %v] [Err: %v] [Acquisition Time: %v]"+
-						" [Current Refresh: %v] [Previous Refresh: %v] [Modified Index: %v]",
-						lockMsgString, err, l.AcquisitionTime, currentRefresh, prevRefresh, kvPair)
 					et.FatalCb(kvdb.ErrLockRefreshFailed,
 						"Error refreshing lock. [Tag %v] [Err: %v] [Acquisition Time: %v]"+
 							" [Current Refresh: %v] [Previous Refresh: %v] [Modified Index: %v]",

--- a/kvdb.go
+++ b/kvdb.go
@@ -98,9 +98,8 @@ const (
 )
 
 const (
-	UseRetryWrapperOption       = "UseRetryWrapper"
-	UseLogWrapperOption         = "UseLogWrapperOption"
-	LogWrapperOptionLogFilePath = "LogWrapperOptionLogFilePath"
+	WrapperEnableLog          = "WrapperEnableLog"
+	WrapperEnableQuorumFilter = "WrapperEnableQuorumFilter"
 )
 
 var (

--- a/kvdb.go
+++ b/kvdb.go
@@ -142,6 +142,12 @@ var (
 	ErrNoQuorum = errors.New("Kvdb lost quorum")
 	// ErrWatchRevisionCompacted requested watch version has been compacted
 	ErrWatchRevisionCompacted = errors.New("Kvdb watch revision compacted")
+	// ErrLockRefreshFailed could not refresh lock key so exclusive access to lock may be lost
+	ErrLockRefreshFailed = errors.New("Failed to refresh lock")
+	// ErrLockHoldTimeoutTriggered triggers if lock is held beyond configured timeout
+	ErrLockHoldTimeoutTriggered = errors.New("Lock held beyond configured timeout")
+	// ErrNoConnection no connection to server
+	ErrNoConnection = errors.New("No server connection")
 )
 
 // KVAction specifies the action on a KV pair. This is useful to make decisions
@@ -160,7 +166,7 @@ type PermissionType int
 type WatchCB func(prefix string, opaque interface{}, kvp *KVPair, err error) error
 
 // FatalErrorCB callback is invoked incase of fatal errors
-type FatalErrorCB func(format string, args ...interface{})
+type FatalErrorCB func(err error, format string, args ...interface{})
 
 // DatastoreInit is called to activate a backend KV store.
 type DatastoreInit func(domain string, machines []string, options map[string]string,

--- a/kvdb.go
+++ b/kvdb.go
@@ -140,6 +140,8 @@ var (
 	ErrMemberDoesNotExist = errors.New("Kvdb member does not exist")
 	// ErrNoQuorum kvdb has lost quorum
 	ErrNoQuorum = errors.New("Kvdb lost quorum")
+	// ErrWatchRevisionCompacted requested watch version has been compacted
+	ErrWatchRevisionCompacted = errors.New("Kvdb watch revision compacted")
 )
 
 // KVAction specifies the action on a KV pair. This is useful to make decisions

--- a/kvdb.go
+++ b/kvdb.go
@@ -167,6 +167,10 @@ type DatastoreInit func(domain string, machines []string, options map[string]str
 // DatastoreVersion is called to get the version of a backend KV store
 type DatastoreVersion func(url string, kvdbOptions map[string]string) (string, error)
 
+// WrapperInit is called to activate a backend KV store.
+type WrapperInit func(kv Kvdb, domain string, machines []string, options map[string]string,
+	cb FatalErrorCB) (Kvdb, error)
+
 // EnumerateSelect function is a callback function provided to EnumerateWithSelect API
 // This fn is executed over all the keys and only those values are returned by Enumerate for which
 // this function return true.
@@ -217,6 +221,13 @@ type Tx interface {
 	// afer commit.
 	Abort() error
 }
+
+type KvdbQuorumState uint32
+
+const (
+	KvdbInQuorum KvdbQuorumState = iota
+	KvdbNotInQuorum
+)
 
 // Kvdb interface implemented by backing datastores.
 type Kvdb interface {
@@ -309,6 +320,10 @@ type Kvdb interface {
 	Serialize() ([]byte, error)
 	// Deserialize deserializes the given byte array into a list of kv pairs
 	Deserialize([]byte) (KVPairs, error)
+	// SetQuorumState sets quorum state
+	SetQuorumState(state KvdbQuorumState)
+	// QuorumState returns quorum state
+	QuorumState() KvdbQuorumState
 }
 
 // ReplayCb provides info required for replay

--- a/kvdb.go
+++ b/kvdb.go
@@ -97,6 +97,11 @@ const (
 	DefaultSeparator = "/"
 )
 
+const (
+	// UseRetryWrapper causes Kvdb to created along with retry wrapper
+	UseRetryWrapper = "UseRetryWrapper"
+)
+
 var (
 	// ErrNotSupported implemenation of a specific function is not supported.
 	ErrNotSupported = errors.New("implementation not supported")

--- a/kvdb.go
+++ b/kvdb.go
@@ -98,8 +98,9 @@ const (
 )
 
 const (
-	// UseRetryWrapper causes Kvdb to created along with retry wrapper
-	UseRetryWrapper = "UseRetryWrapper"
+	UseRetryWrapperOption       = "UseRetryWrapper"
+	UseLogWrapperOption         = "UseLogWrapperOption"
+	LogWrapperOptionLogFilePath = "LogWrapperOptionLogFilePath"
 )
 
 var (

--- a/kvdb.go
+++ b/kvdb.go
@@ -133,6 +133,8 @@ var (
 	// ErrMemberDoesNotExist returned when an operation fails for a member
 	// which does not exist
 	ErrMemberDoesNotExist = errors.New("Kvdb member does not exist")
+	// ErrNoQuorum kvdb has lost quorum
+	ErrNoQuorum = errors.New("Kvdb lost quorum")
 )
 
 // KVAction specifies the action on a KV pair. This is useful to make decisions

--- a/kvdb_mgr.go
+++ b/kvdb_mgr.go
@@ -47,7 +47,7 @@ func New(
 	if dsInit, exists := datastores[name]; exists {
 		kvdb, err := dsInit(domain, machines, options, errorCB)
 		for _, wrapperOption := range []string{UseRetryWrapperOption, UseLogWrapperOption} {
-			if _, ok := options[wrapperOption]; ok && err != nil {
+			if _, ok := options[wrapperOption]; ok && err == nil {
 				kvdb, err = wrappers[wrapperOption](kvdb, domain, machines, options, errorCB)
 			}
 			if err != nil {

--- a/kvdb_mgr.go
+++ b/kvdb_mgr.go
@@ -45,6 +45,9 @@ func New(
 
 	if dsInit, exists := datastores[name]; exists {
 		kvdb, err := dsInit(domain, machines, options, errorCB)
+		if _, ok := options[UseRetryWrapper]; ok && err != nil {
+			wrapper.New(kvdb, name, domain, machines, options, errorCB)
+		}
 		return kvdb, err
 	}
 	return nil, ErrNotSupported

--- a/kvdb_mgr.go
+++ b/kvdb_mgr.go
@@ -46,7 +46,7 @@ func New(
 
 	if dsInit, exists := datastores[name]; exists {
 		kvdb, err := dsInit(domain, machines, options, errorCB)
-		for _, wrapperOption := range []string{UseRetryWrapperOption, UseLogWrapperOption} {
+		for _, wrapperOption := range []string{WrapperEnableLog, WrapperEnableQuorumFilter} {
 			if _, ok := options[wrapperOption]; ok && err == nil {
 				kvdb, err = wrappers[wrapperOption](kvdb, domain, machines, options, errorCB)
 			}

--- a/kvdb_mgr.go
+++ b/kvdb_mgr.go
@@ -46,8 +46,13 @@ func New(
 
 	if dsInit, exists := datastores[name]; exists {
 		kvdb, err := dsInit(domain, machines, options, errorCB)
-		if _, ok := options[UseRetryWrapperOption]; ok && err != nil {
-			wrappers[UseRetryWrapperOption](kvdb, domain, machines, options, errorCB)
+		for _, wrapperOption := range []string{UseRetryWrapperOption, UseLogWrapperOption} {
+			if _, ok := options[wrapperOption]; ok && err != nil {
+				kvdb, err = wrappers[wrapperOption](kvdb, domain, machines, options, errorCB)
+			}
+			if err != nil {
+				break
+			}
 		}
 		return kvdb, err
 	}

--- a/kvdb_mgr.go
+++ b/kvdb_mgr.go
@@ -46,8 +46,8 @@ func New(
 
 	if dsInit, exists := datastores[name]; exists {
 		kvdb, err := dsInit(domain, machines, options, errorCB)
-		if _, ok := options[UseRetryWrapper]; ok && err != nil {
-			wrappers[UseRetryWrapper](kvdb, domain, machines, options, errorCB)
+		if _, ok := options[UseRetryWrapperOption]; ok && err != nil {
+			wrappers[UseRetryWrapperOption](kvdb, domain, machines, options, errorCB)
 		}
 		return kvdb, err
 	}

--- a/test/kv.go
+++ b/test/kv.go
@@ -63,42 +63,36 @@ func Run(datastoreInit kvdb.DatastoreInit, t *testing.T, start StartKvdb, stop S
 	if err != nil {
 		t.Fatalf(err.Error())
 	}
-	kvWrapper, err := wrappers.NewKvQuorumCheckFilter(kvStore, "pwx/test", nil, nil, fatalErrorCb())
+	kv, err := wrappers.NewKvQuorumCheckFilter(kvStore, "pwx/test", nil, nil, fatalErrorCb())
 	if err != nil {
 		t.Fatalf(err.Error())
 	}
-	for _, useWrapper := range []bool{false, true} {
-		kv := kvStore
-		if useWrapper {
-			kv = kvWrapper
-		}
-		create(kv, t)
-		createWithTTL(kv, t)
-		cas(kv, t)
-		cad(kv, t)
-		snapshot(kv, t)
-		get(kv, t)
-		getInterface(kv, t)
-		update(kv, t)
-		deleteKey(kv, t)
-		deleteTree(kv, t)
-		enumerate(kv, t)
-		keys(kv, t)
-		concurrentEnum(kv, t)
-		watchKey(kv, t)
-		watchTree(kv, t)
-		watchWithIndex(kv, t)
-		collect(kv, t)
-		lockBasic(kv, t)
-		lock(kv, t)
-		lockBetweenRestarts(kv, t, start, stop)
-		serialization(kv, t)
-	}
+	create(kv, t)
+	createWithTTL(kv, t)
+	cas(kv, t)
+	cad(kv, t)
+	snapshot(kv, t)
+	get(kv, t)
+	getInterface(kv, t)
+	update(kv, t)
+	deleteKey(kv, t)
+	deleteTree(kv, t)
+	enumerate(kv, t)
+	keys(kv, t)
+	concurrentEnum(kv, t)
+	watchKey(kv, t)
+	watchTree(kv, t)
+	watchWithIndex(kv, t)
+	collect(kv, t)
+	lockBasic(kv, t)
+	lock(kv, t)
+	lockBetweenRestarts(kv, t, start, stop)
+	serialization(kv, t)
 	err = stop()
 	assert.NoError(t, err, "Unable to stop kvdb")
 	// ensure wrapper does not crash when kvdb members are stopped.
-	kvWrapper.SetQuorumState(kvdb.KvdbNotInQuorum)
-	noQuorum(kvWrapper, t)
+	kv.SetQuorumState(kvdb.KvdbNotInQuorum)
+	noQuorum(kv, t)
 }
 
 // RunBasic runs the basic test suite.

--- a/test/kv.go
+++ b/test/kv.go
@@ -67,10 +67,6 @@ func Run(datastoreInit kvdb.DatastoreInit, t *testing.T, start StartKvdb, stop S
 	if err != nil {
 		t.Fatalf(err.Error())
 	}
-	kvWrapper, err = wrappers.NewLogWrapper(kvWrapper, "pwx/test", nil, nil, fatalErrorCb())
-	if err != nil {
-		t.Fatalf(err.Error())
-	}
 	for _, useWrapper := range []bool{false, true} {
 		kv := kvStore
 		if useWrapper {

--- a/test/kv.go
+++ b/test/kv.go
@@ -1537,15 +1537,6 @@ func noQuorum(kv kvdb.Kvdb, t *testing.T) {
 	_, err = kv.CompareAndSet(kvp, 0, []byte(value))
 	assert.Error(t, err, kvdb.ErrNoQuorum, "error expected in CompareAndSet")
 
-	watchCb := func(prefix string, opaque interface{}, kvp *kvdb.KVPair, err error) error {
-		assert.Error(t, err, "watch error expected")
-		return err
-	}
-	err = kv.WatchKey(key, ttl, key, watchCb)
-	assert.Error(t, err, kvdb.ErrNoQuorum, "error expected in WatchKey")
-	err = kv.WatchTree(key, ttl, key, watchCb)
-	assert.Error(t, err, kvdb.ErrNoQuorum, "error expected in WatchTree")
-
 	_, err = kv.Lock(key)
 	assert.Error(t, err, kvdb.ErrNoQuorum, "error expected in Lock")
 	_, err = kv.LockWithID(key, key)
@@ -1585,4 +1576,11 @@ func noQuorum(kv kvdb.Kvdb, t *testing.T) {
 	err = kv.DeleteTree(key)
 	assert.Error(t, err, kvdb.ErrNoQuorum, "error expected in DeleteTree")
 
+	// watch must return an error
+	watchCb := func(prefix string, opaque interface{}, kvp *kvdb.KVPair, err error) error {
+		assert.Error(t, err, "watch error expected")
+		return err
+	}
+	kv.WatchKey(key, ttl, key, watchCb)
+	kv.WatchTree(key, ttl, key, watchCb)
 }

--- a/test/kv.go
+++ b/test/kv.go
@@ -63,7 +63,7 @@ func Run(datastoreInit kvdb.DatastoreInit, t *testing.T, start StartKvdb, stop S
 	if err != nil {
 		t.Fatalf(err.Error())
 	}
-	kvWrapper, err := wrappers.New(kvStore, "pwx/test", nil, nil, fatalErrorCb())
+	kvWrapper, err := wrappers.NewKvQuorumCheckFilter(kvStore, "pwx/test", nil, nil, fatalErrorCb())
 	if err != nil {
 		t.Fatalf(err.Error())
 	}
@@ -71,35 +71,33 @@ func Run(datastoreInit kvdb.DatastoreInit, t *testing.T, start StartKvdb, stop S
 	if err != nil {
 		t.Fatalf(err.Error())
 	}
-	/*
-		for _, useWrapper := range []bool{false, true} {
-			kv := kvStore
-			if useWrapper {
-				kv = kvWrapper
-			}
-			create(kv, t)
-			createWithTTL(kv, t)
-			cas(kv, t)
-			cad(kv, t)
-			snapshot(kv, t)
-			get(kv, t)
-			getInterface(kv, t)
-			update(kv, t)
-			deleteKey(kv, t)
-			deleteTree(kv, t)
-			enumerate(kv, t)
-			keys(kv, t)
-			concurrentEnum(kv, t)
-			watchKey(kv, t)
-			watchTree(kv, t)
-			watchWithIndex(kv, t)
-			collect(kv, t)
-			lockBasic(kv, t)
-			lock(kv, t)
-			lockBetweenRestarts(kv, t, start, stop)
-			serialization(kv, t)
+	for _, useWrapper := range []bool{false, true} {
+		kv := kvStore
+		if useWrapper {
+			kv = kvWrapper
 		}
-	*/
+		create(kv, t)
+		createWithTTL(kv, t)
+		cas(kv, t)
+		cad(kv, t)
+		snapshot(kv, t)
+		get(kv, t)
+		getInterface(kv, t)
+		update(kv, t)
+		deleteKey(kv, t)
+		deleteTree(kv, t)
+		enumerate(kv, t)
+		keys(kv, t)
+		concurrentEnum(kv, t)
+		watchKey(kv, t)
+		watchTree(kv, t)
+		watchWithIndex(kv, t)
+		collect(kv, t)
+		lockBasic(kv, t)
+		lock(kv, t)
+		lockBetweenRestarts(kv, t, start, stop)
+		serialization(kv, t)
+	}
 	err = stop()
 	assert.NoError(t, err, "Unable to stop kvdb")
 	// ensure wrapper does not crash when kvdb members are stopped.

--- a/test/kv.go
+++ b/test/kv.go
@@ -42,8 +42,7 @@ type lockTag struct {
 }
 
 func fatalErrorCb() kvdb.FatalErrorCB {
-	return func(format string, args ...interface{}) {
-		logrus.Panicf(format, args)
+	return func(err error, format string, args ...interface{}) {
 	}
 }
 
@@ -804,7 +803,8 @@ func lock(kv kvdb.Kvdb, t *testing.T) {
 		assert.NoError(t, err, "Unexpected error from Unlock")
 
 		lockTimedout := false
-		fatalLockCb := func(format string, args ...interface{}) {
+		fatalLockCb := func(err error, format string, args ...interface{}) {
+			assert.Equal(t, err, kvdb.ErrLockHoldTimeoutTriggered)
 			logrus.Infof("Lock timeout called: "+format, args...)
 			lockTimedout = true
 		}

--- a/test/kv.go
+++ b/test/kv.go
@@ -804,7 +804,6 @@ func lock(kv kvdb.Kvdb, t *testing.T) {
 
 		lockTimedout := false
 		fatalLockCb := func(err error, format string, args ...interface{}) {
-			assert.Equal(t, err, kvdb.ErrLockHoldTimeoutTriggered)
 			logrus.Infof("Lock timeout called: "+format, args...)
 			lockTimedout = true
 		}

--- a/test/kv.go
+++ b/test/kv.go
@@ -67,6 +67,10 @@ func Run(datastoreInit kvdb.DatastoreInit, t *testing.T, start StartKvdb, stop S
 	if err != nil {
 		t.Fatalf(err.Error())
 	}
+	kvWrapper, err = wrappers.NewLogWrapper(kvWrapper, "pwx/test", nil, nil, fatalErrorCb())
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
 	/*
 		for _, useWrapper := range []bool{false, true} {
 			kv := kvStore

--- a/wrappers/kv_log.go
+++ b/wrappers/kv_log.go
@@ -1,0 +1,461 @@
+package wrappers
+
+import (
+	"os"
+	"time"
+
+	"github.com/portworx/kvdb"
+	"github.com/sirupsen/logrus"
+)
+
+type kvLogger struct {
+	// kv is the kvdb which is wrapped
+	kv kvdb.Kvdb
+	// logger logs the input/output
+	logger *logrus.Logger
+}
+
+const (
+	defaultPath = "/var/cores/kv_log.txt"
+	opType      = "operation"
+	errString   = "error"
+	output      = "output"
+)
+
+// New constructs a new kvdb.Kvdb.
+func newLogger(
+	kv kvdb.Kvdb,
+	domain string,
+	machines []string,
+	options map[string]string,
+	fatalErrorCb kvdb.FatalErrorCB,
+) (kvdb.Kvdb, error) {
+	path := defaultPath
+	if value, ok := options[kvdb.LogWrapperOptionLogFilePath]; ok && len(value) > 0 {
+		path = value
+	}
+
+	f, err := os.OpenFile(path, os.O_WRONLY|os.O_APPEND|os.O_CREATE, 0644)
+	if err != nil {
+		logrus.Errorf("failed to open log file (%s) for kvdb: %v", err, path)
+		return kv, err
+	}
+
+	log := logrus.New()
+	log.SetOutput(f)
+
+	logrus.Infof("Registering with logging wrapper, path: %s", path)
+	return &kvLogger{
+		kv:     kv,
+		logger: log,
+	}, nil
+}
+
+func (k *kvLogger) inQuorum() bool {
+	return k.inQuorum()
+}
+
+func (k *kvLogger) SetQuorumState(state kvdb.KvdbQuorumState) {
+	k.kv.SetQuorumState(state)
+}
+
+func (k *kvLogger) QuorumState() kvdb.KvdbQuorumState {
+	return k.kv.QuorumState()
+}
+
+func (k *kvLogger) String() string {
+	return k.kv.String()
+}
+
+func (k *kvLogger) Capabilities() int {
+	return k.kv.Capabilities()
+}
+
+func (k *kvLogger) Get(key string) (*kvdb.KVPair, error) {
+	pair, err := k.kv.Get(key)
+	k.logger.WithFields(logrus.Fields{
+		opType:    "Get",
+		output:    pair,
+		errString: err,
+	})
+	return pair, err
+}
+
+func (k *kvLogger) Snapshot(prefixes []string, consistent bool) (kvdb.Kvdb, uint64, error) {
+	kv, version, err := k.kv.Snapshot(prefixes, consistent)
+	k.logger.WithFields(logrus.Fields{
+		opType:    "Snapshot",
+		errString: err,
+	})
+	return kv, version, err
+}
+
+func (k *kvLogger) Put(
+	key string,
+	value interface{},
+	ttl uint64,
+) (*kvdb.KVPair, error) {
+	pair, err := k.kv.Put(key, value, ttl)
+	k.logger.WithFields(logrus.Fields{
+		opType:    "Put",
+		output:    pair,
+		errString: err,
+	})
+	return pair, err
+}
+
+func (k *kvLogger) GetVal(key string, v interface{}) (*kvdb.KVPair, error) {
+	pair, err := k.kv.GetVal(key, v)
+	k.logger.WithFields(logrus.Fields{
+		opType:    "GetValue",
+		output:    pair,
+		errString: err,
+	})
+	return pair, err
+}
+
+func (k *kvLogger) Create(
+	key string,
+	value interface{},
+	ttl uint64,
+) (*kvdb.KVPair, error) {
+	pair, err := k.kv.Create(key, value, ttl)
+	k.logger.WithFields(logrus.Fields{
+		opType:    "Create",
+		output:    pair,
+		errString: err,
+	})
+	return pair, err
+}
+
+func (k *kvLogger) Update(
+	key string,
+	value interface{},
+	ttl uint64,
+) (*kvdb.KVPair, error) {
+	pair, err := k.kv.Update(key, value, ttl)
+	k.logger.WithFields(logrus.Fields{
+		opType:    "Update",
+		output:    pair,
+		errString: err,
+	})
+	return pair, err
+}
+
+func (k *kvLogger) Enumerate(prefix string) (kvdb.KVPairs, error) {
+	pairs, err := k.kv.Enumerate(prefix)
+	k.logger.WithFields(logrus.Fields{
+		opType:    "Enumerate",
+		"length":  len(pairs),
+		errString: err,
+	})
+	return pairs, err
+}
+
+func (k *kvLogger) Delete(key string) (*kvdb.KVPair, error) {
+	pair, err := k.kv.Delete(key)
+	k.logger.WithFields(logrus.Fields{
+		opType:    "Delete",
+		output:    pair,
+		errString: err,
+	})
+	return pair, err
+}
+
+func (k *kvLogger) DeleteTree(prefix string) error {
+	err := k.kv.DeleteTree(prefix)
+	k.logger.WithFields(logrus.Fields{
+		opType:    "DeleteTree",
+		errString: err,
+	})
+	return err
+}
+
+func (k *kvLogger) Keys(prefix, sep string) ([]string, error) {
+	keys, err := k.kv.Keys(prefix, sep)
+	k.logger.WithFields(logrus.Fields{
+		opType:    "Keys",
+		"length":  len(keys),
+		errString: err,
+	})
+	return keys, err
+}
+
+func (k *kvLogger) CompareAndSet(
+	kvp *kvdb.KVPair,
+	flags kvdb.KVFlags,
+	prevValue []byte,
+) (*kvdb.KVPair, error) {
+	pair, err := k.kv.CompareAndSet(kvp, flags, prevValue)
+	k.logger.WithFields(logrus.Fields{
+		opType:    "CompareAndSet",
+		output:    pair,
+		errString: err,
+	})
+	return pair, err
+}
+
+func (k *kvLogger) CompareAndDelete(
+	kvp *kvdb.KVPair,
+	flags kvdb.KVFlags,
+) (*kvdb.KVPair, error) {
+	pair, err := k.kv.CompareAndDelete(kvp, flags)
+	k.logger.WithFields(logrus.Fields{
+		opType:    "CompareAndDelete",
+		output:    pair,
+		errString: err,
+	})
+	return pair, err
+}
+
+func (k *kvLogger) WatchKey(
+	key string,
+	waitIndex uint64,
+	opaque interface{},
+	cb kvdb.WatchCB,
+) error {
+	err := k.kv.WatchKey(key, waitIndex, opaque, cb)
+	k.logger.WithFields(logrus.Fields{
+		opType:    "WatchKey",
+		errString: err,
+	})
+	return err
+}
+
+func (k *kvLogger) WatchTree(
+	prefix string,
+	waitIndex uint64,
+	opaque interface{},
+	cb kvdb.WatchCB,
+) error {
+	err := k.kv.WatchTree(prefix, waitIndex, opaque, cb)
+	k.logger.WithFields(logrus.Fields{
+		opType:    "WatchTrer",
+		errString: err,
+	})
+	return err
+}
+
+func (k *kvLogger) Lock(key string) (*kvdb.KVPair, error) {
+	pair, err := k.kv.Lock(key)
+	k.logger.WithFields(logrus.Fields{
+		opType:    "Lock",
+		output:    pair,
+		errString: err,
+	})
+	return pair, err
+}
+
+func (k *kvLogger) LockWithID(
+	key string,
+	lockerID string,
+) (*kvdb.KVPair, error) {
+	pair, err := k.kv.LockWithID(key, lockerID)
+	k.logger.WithFields(logrus.Fields{
+		opType:    "LockWithID",
+		output:    pair,
+		errString: err,
+	})
+	return pair, err
+}
+
+func (k *kvLogger) LockWithTimeout(
+	key string,
+	lockerID string,
+	lockTryDuration time.Duration,
+	lockHoldDuration time.Duration,
+) (*kvdb.KVPair, error) {
+	pair, err := k.kv.LockWithTimeout(key, lockerID, lockTryDuration, lockHoldDuration)
+	k.logger.WithFields(logrus.Fields{
+		opType:    "LockWithTimeout",
+		output:    pair,
+		errString: err,
+	})
+	return pair, err
+}
+
+func (k *kvLogger) Unlock(kvp *kvdb.KVPair) error {
+	err := k.kv.Unlock(kvp)
+	k.logger.WithFields(logrus.Fields{
+		opType:    "Unlock",
+		errString: err,
+	})
+	return err
+}
+
+func (k *kvLogger) EnumerateWithSelect(
+	prefix string,
+	enumerateSelect kvdb.EnumerateSelect,
+	copySelect kvdb.CopySelect,
+) ([]interface{}, error) {
+	vals, err := k.kv.EnumerateWithSelect(prefix, enumerateSelect, copySelect)
+	k.logger.WithFields(logrus.Fields{
+		opType:    "EnumerateWithSelect",
+		"length":  len(vals),
+		errString: err,
+	})
+	return vals, err
+}
+
+func (k *kvLogger) GetWithCopy(
+	key string,
+	copySelect kvdb.CopySelect,
+) (interface{}, error) {
+	pair, err := k.kv.GetWithCopy(key, copySelect)
+	k.logger.WithFields(logrus.Fields{
+		opType:    "GetWithCopy",
+		output:    pair,
+		errString: err,
+	})
+	return pair, err
+}
+
+func (k *kvLogger) TxNew() (kvdb.Tx, error) {
+	tx, err := k.kv.TxNew()
+	k.logger.WithFields(logrus.Fields{
+		opType:    "Snapshot",
+		errString: err,
+	})
+	return tx, err
+}
+
+func (k *kvLogger) SnapPut(snapKvp *kvdb.KVPair) (*kvdb.KVPair, error) {
+	pair, err := k.kv.SnapPut(snapKvp)
+	k.logger.WithFields(logrus.Fields{
+		opType:    "SnapPut",
+		output:    pair,
+		errString: err,
+	})
+	return pair, err
+}
+
+func (k *kvLogger) AddUser(username string, password string) error {
+	err := k.kv.AddUser(username, password)
+	k.logger.WithFields(logrus.Fields{
+		opType:    "AddUser",
+		errString: err,
+	})
+	return err
+}
+
+func (k *kvLogger) RemoveUser(username string) error {
+	err := k.kv.RemoveUser(username)
+	k.logger.WithFields(logrus.Fields{
+		opType:    "RemoveUser",
+		errString: err,
+	})
+	return err
+}
+
+func (k *kvLogger) GrantUserAccess(
+	username string,
+	permType kvdb.PermissionType,
+	subtree string,
+) error {
+	err := k.kv.GrantUserAccess(username, permType, subtree)
+	k.logger.WithFields(logrus.Fields{
+		opType:    "GrantUserAccess",
+		errString: err,
+	})
+	return err
+}
+
+func (k *kvLogger) RevokeUsersAccess(
+	username string,
+	permType kvdb.PermissionType,
+	subtree string,
+) error {
+	err := k.kv.RevokeUsersAccess(username, permType, subtree)
+	k.logger.WithFields(logrus.Fields{
+		opType:    "RevokeUsersAccess",
+		errString: err,
+	})
+	return err
+}
+
+func (k *kvLogger) SetFatalCb(f kvdb.FatalErrorCB) {
+	k.kv.SetFatalCb(f)
+}
+
+func (k *kvLogger) SetLockTimeout(timeout time.Duration) {
+	k.kv.SetLockTimeout(timeout)
+}
+
+func (k *kvLogger) GetLockTimeout() time.Duration {
+	return k.kv.GetLockTimeout()
+}
+
+func (k *kvLogger) Serialize() ([]byte, error) {
+	return k.kv.Serialize()
+}
+
+func (k *kvLogger) Deserialize(b []byte) (kvdb.KVPairs, error) {
+	return k.kv.Deserialize(b)
+}
+
+func (k *kvLogger) AddMember(nodeIP, nodePeerPort, nodeName string) (map[string][]string, error) {
+	members, err := k.kv.AddMember(nodeIP, nodePeerPort, nodeName)
+	k.logger.WithFields(logrus.Fields{
+		opType:    "AddMember",
+		output:    members,
+		errString: err,
+	})
+	return members, err
+}
+
+func (k *kvLogger) RemoveMember(nodeName, nodeIP string) error {
+	err := k.kv.RemoveMember(nodeName, nodeIP)
+	k.logger.WithFields(logrus.Fields{
+		opType:    "RemoveMember",
+		errString: err,
+	})
+	return err
+}
+
+func (k *kvLogger) UpdateMember(nodeIP, nodePeerPort, nodeName string) (map[string][]string, error) {
+	members, err := k.kv.UpdateMember(nodeIP, nodePeerPort, nodeName)
+	k.logger.WithFields(logrus.Fields{
+		opType:    "UpdateMember",
+		output:    members,
+		errString: err,
+	})
+	return members, err
+}
+
+func (k *kvLogger) ListMembers() (map[string]*kvdb.MemberInfo, error) {
+	members, err := k.kv.ListMembers()
+	k.logger.WithFields(logrus.Fields{
+		opType:    "ListMembers",
+		output:    members,
+		errString: err,
+	})
+	return members, err
+}
+
+func (k *kvLogger) SetEndpoints(endpoints []string) error {
+	err := k.kv.SetEndpoints(endpoints)
+	k.logger.WithFields(logrus.Fields{
+		opType:    "SetEndpoints",
+		errString: err,
+	})
+	return err
+}
+
+func (k *kvLogger) GetEndpoints() []string {
+	endpoints := k.kv.GetEndpoints()
+	k.logger.WithFields(logrus.Fields{
+		opType: "GetEndpoints",
+		output: endpoints,
+	})
+	return endpoints
+}
+
+func (k *kvLogger) Defragment(endpoint string, timeout int) error {
+	return k.kv.Defragment(endpoint, timeout)
+}
+
+func init() {
+	if err := kvdb.RegisterWrapper(kvdb.UseLogWrapperOption, newLogger); err != nil {
+		panic(err.Error())
+	}
+}

--- a/wrappers/kv_log.go
+++ b/wrappers/kv_log.go
@@ -211,7 +211,7 @@ func (k *kvLogger) WatchTree(
 ) error {
 	err := k.kv.WatchTree(prefix, waitIndex, opaque, cb)
 	logrus.WithFields(logrus.Fields{
-		opType:    "WatchTrer",
+		opType:    "WatchTree",
 		errString: err,
 	}).Info()
 	return err

--- a/wrappers/kv_retry.go
+++ b/wrappers/kv_retry.go
@@ -173,11 +173,11 @@ func (k *kvRetry) GetWithCopy(
 }
 
 func (k *kvRetry) TxNew() (kvdb.Tx, error) {
-	return nil, kvdb.ErrNotSupported
+	return k.kv.TxNew()
 }
 
 func (k *kvRetry) SnapPut(snapKvp *kvdb.KVPair) (*kvdb.KVPair, error) {
-	return nil, kvdb.ErrNotSupported
+	return k.kv.SnapPut(snapKvp)
 }
 
 func (k *kvRetry) AddUser(username string, password string) error {

--- a/wrappers/kv_retry.go
+++ b/wrappers/kv_retry.go
@@ -391,4 +391,7 @@ func init() {
 	if err := kvdb.RegisterWrapper(kvdb.UseRetryWrapperOption, New); err != nil {
 		panic(err.Error())
 	}
+	if err := kvdb.RegisterWrapper(kvdb.UseLogWrapperOption, NewLogWrapper); err != nil {
+		panic(err.Error())
+	}
 }

--- a/wrappers/kv_retry.go
+++ b/wrappers/kv_retry.go
@@ -1,0 +1,213 @@
+package mem
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/portworx/kvdb"
+	"github.com/portworx/kvdb/common"
+	"github.com/sirupsen/logrus"
+)
+
+type kvRetry struct {
+	// kv is the kvdb which is wrapped
+	kv kvdb.Kvdb
+	// hasQuorum is true if kv has quorum
+	hasQuorum bool
+	// mutex protects hasQuorum
+	mutex sync.Mutex
+}
+
+// New constructs a new kvdb.Kvdb.
+func New(
+	kv kvdb.Kvdb,
+	domain string,
+	machines []string,
+	options map[string]string,
+	fatalErrorCb kvdb.FatalErrorCB,
+) (kvdb.Kvdb, error) {
+	return &kvRetry{
+		kv: kv,
+	}
+}
+
+// Version returns the supported version of the mem implementation
+func Version(url string, kvdbOptions map[string]string) (string, error) {
+	return kvdb.MemVersion1, nil
+}
+
+func (k *kvRetry) String() string {
+	return k.kv.String()
+}
+
+func (k *kvRetry) Capabilities() int {
+	return k.kv.Capabilities()
+}
+
+func (k *kvRetry) Get(key string) (*kvdb.KVPair, error) {
+	return k.kv.Get(key)
+}
+
+func (k *kvRetry) Snapshot(prefixes []string, consistent bool) (kvdb.Kvdb, uint64, error) {
+	return k.kv.Snapshot(prefixes, consistent)
+}
+
+func (k *kvRetry) Put(
+	key string,
+	value interface{},
+	ttl uint64,
+) (*kvdb.KVPair, error) {
+	return k.kv.Put(key, value, ttl)
+}
+
+func (k *kvRetry) GetVal(key string, v interface{}) (*kvdb.KVPair, error) {
+	return k.kv.GetVal(key, v)
+}
+
+func (k *kvRetry) Create(
+	key string,
+	value interface{},
+	ttl uint64,
+) (*kvdb.KVPair, error) {
+	return k.kv.Create(key, value, ttl)
+}
+
+func (k *kvRetry) Update(
+	key string,
+	value interface{},
+	ttl uint64,
+) (*kvdb.KVPair, error) {
+	return k.kv.Update(key, value, ttl)
+}
+
+func (k *kvRetry) Enumerate(prefix string) (kvdb.KVPairs, error) {
+	return k.kv.Enumerate(prefix)
+}
+
+func (k *kvRetry) Delete(key string) (*kvdb.KVPair, error) {
+	return k.kv.Delete(key)
+}
+
+func (k *kvRetry) DeleteTree(prefix string) error {
+	return k.kv.DeleteTree(prefix)
+}
+
+func (k *kvRetry) Keys(prefix, sep string) ([]string, error) {
+	return k.kv.Keys(prefix, sep)
+}
+
+func (k *kvRetry) CompareAndSet(
+	kvp *kvdb.KVPair,
+	flags kvdb.KVFlags,
+	prevValue []byte,
+) (*kvdb.KVPair, error) {
+	return k.kv.CompareAndSet(kvp, flags, prevValue)
+}
+
+func (k *kvRetry) CompareAndDelete(
+	kvp *kvdb.KVPair,
+	flags kvdb.KVFlags,
+) (*kvdb.KVPair, error) {
+	return k.kv.CompareAndDelete(kvp, flags)
+}
+
+func (k *kvRetry) WatchKey(
+	key string,
+	waitIndex uint64,
+	opaque interface{},
+	cb kvdb.WatchCB,
+) error {
+	return k.kv.WatchKey(key, waitIndex, opaque, cb)
+}
+
+func (k *kvRetry) WatchTree(
+	prefix string,
+	waitIndex uint64,
+	opaque interface{},
+	cb kvdb.WatchCB,
+) error {
+	return k.kv.WatchTree(prefix, waitIndex, opaque, cb)
+}
+
+func (k *kvRetry) Lock(key string) (*kvdb.KVPair, error) {
+	return k.kv.Lock(key)
+}
+
+func (k *kvRetry) LockWithID(
+	key string,
+	lockerID string,
+) (*kvdb.KVPair, error) {
+	return k.kv.LockWithID(key, lockerID)
+}
+
+func (k *kvRetry) LockWithTimeout(
+	key string,
+	lockerID string,
+	lockTryDuration time.Duration,
+	lockHoldDuration time.Duration,
+) (*kvdb.KVPair, error) {
+	return k.kv.LockWithTimeout(key, lockerID, lockTryDuration, lockHoldDuration)
+}
+
+func (k *kvRetry) Unlock(kvp *kvdb.KVPair) error {
+	return k.kv.Unlock(kvp)
+}
+
+func (k *kvRetry) EnumerateWithSelect(
+	prefix string,
+	enumerateSelect kvdb.EnumerateSelect,
+	copySelect kvdb.CopySelect,
+) ([]interface{}, error) {
+	return k.kv.EnumerateWithSelect(prefix, enumerateSelect, copySelect)
+}
+
+func (k *kvRetry) GetWithCopy(
+	key string,
+	copySelect kvdb.CopySelect,
+) (interface{}, error) {
+	return k.kv.GetWithCopy(key, copySelect)
+}
+
+func (k *kvRetry) TxNew() (kvdb.Tx, error) {
+	return nil, kvdb.ErrNotSupported
+}
+
+func (k *kvRetry) SnapPut(snapKvp *kvdb.KVPair) (*kvdb.KVPair, error) {
+	return nil, kvdb.ErrNotSupported
+}
+
+func (k *kvRetry) AddUser(username string, password string) error {
+	return k.kv.AddUser(username, password)
+}
+
+func (k *kvRetry) RemoveUser(username string) error {
+	return k.kv.RemoveUser(username)
+}
+
+func (k *kvRetry) GrantUserAccess(
+	username string,
+	permType kvdb.PermissionType,
+	subtree string,
+) error {
+	return k.kv.GrantUserAccess(username, permType, subtree)
+}
+
+func (k *kvRetry) RevokeUsersAccess(
+	username string,
+	permType kvdb.PermissionType,
+	subtree string,
+) error {
+	return k.kv.RevokeUsersAccess(username, permType, subtree)
+}
+
+func (k *kvRetry) Serialize() ([]byte, error) {
+	return k.kv.Serialize()
+}
+
+func (k *kvRetry) Deserialize(b []byte) (kvdb.KVPairs, error) {
+	return k.kv.DeserializeAll(b)
+}

--- a/wrappers/kv_retry.go
+++ b/wrappers/kv_retry.go
@@ -388,7 +388,7 @@ func (k *kvRetry) Defragment(endpoint string, timeout int) error {
 }
 
 func init() {
-	if err := kvdb.RegisterWrapper(kvdb.UseRetryWrapper, New); err != nil {
+	if err := kvdb.RegisterWrapper(kvdb.UseRetryWrapperOption, New); err != nil {
 		panic(err.Error())
 	}
 }

--- a/zookeeper/kv_zookeeper.go
+++ b/zookeeper/kv_zookeeper.go
@@ -512,7 +512,7 @@ func (z *zookeeperKV) waitForUnlock(
 					}
 					l.Unlocked = true
 				}
-				z.FatalCb("Lock %s hold timeout triggered", lockMsgString)
+				z.LockTimedout(lockMsgString)
 				return
 			}
 		case <-l.Done:


### PR DESCRIPTION
1. fatalCB change:
- callback function passed an error allowing more to be passed to clients.

2. on CAD/CAS errors:
- call fatalCB
- return the error since fatalCB may not abort the process.

3. lock/unlock refresh errors:
- call fatalCB with LockRefresh error. This allows client app to decide if to continue or abort.
- stop refreshing if unlock fails and return success.

3. Wrappers:
- add a wrapper interface for log, which simply logs the input/output.
- add a wrapper interface for quorum check.
   - allows setting kvdb state to quorum/no-quorum
   - when state is quorum - all calls go to wrapped kvdb
   - when not in quorum - call is immediately returned with kvdb not in quorum error. 
   - add UTs

4. Add error type to be returned when watch is closed because required indexes have been compacted (for etcd for example).



