### PR TITLE
Add EnumerateKVPWithSelect API.

### DIFF
--- a/bolt/kv_bolt.go
+++ b/bolt/kv_bolt.go
@@ -944,6 +944,14 @@ func (kv *boltKV) EnumerateWithSelect(
 	return nil, kvdb.ErrNotSupported
 }
 
+func (kv *boltKV) EnumerateKVPWithSelect(
+	prefix string,
+	enumerateSelect kvdb.EnumerateKVPSelect,
+	copySelect kvdb.CopyKVPSelect,
+) (kvdb.KVPairs, error) {
+	return nil, kvdb.ErrNotSupported
+}
+
 func (kv *boltKV) GetWithCopy(
 	key string,
 	copySelect kvdb.CopySelect,

--- a/consul/kv_consul.go
+++ b/consul/kv_consul.go
@@ -840,6 +840,14 @@ func (kv *consulKV) EnumerateWithSelect(
 	return nil, kvdb.ErrNotSupported
 }
 
+func (kv *consulKV) EnumerateKVPWithSelect(
+	prefix string,
+	enumerateSelect kvdb.EnumerateKVPSelect,
+	copySelect kvdb.CopyKVPSelect,
+) (kvdb.KVPairs, error) {
+	return nil, kvdb.ErrNotSupported
+}
+
 func (kv *consulKV) GetWithCopy(
 	key string,
 	copySelect kvdb.CopySelect,

--- a/etcd/v2/kv_etcd.go
+++ b/etcd/v2/kv_etcd.go
@@ -858,6 +858,14 @@ func (kv *etcdKV) EnumerateWithSelect(
 	return nil, kvdb.ErrNotSupported
 }
 
+func (kv *etcdKV) EnumerateKVPWithSelect(
+	prefix string,
+	enumerateSelect kvdb.EnumerateKVPSelect,
+	copySelect kvdb.CopyKVPSelect,
+) (kvdb.KVPairs, error) {
+	return nil, kvdb.ErrNotSupported
+}
+
 func (kv *etcdKV) GetWithCopy(
 	key string,
 	copySelect kvdb.CopySelect,

--- a/etcd/v3/kv_etcd.go
+++ b/etcd/v3/kv_etcd.go
@@ -1256,6 +1256,14 @@ func (et *etcdKV) EnumerateWithSelect(
 	return nil, kvdb.ErrNotSupported
 }
 
+func (et *etcdKV) EnumerateKVPWithSelect(
+	prefix string,
+	enumerateSelect kvdb.EnumerateKVPSelect,
+	copySelect kvdb.CopyKVPSelect,
+) (kvdb.KVPairs, error) {
+	return nil, kvdb.ErrNotSupported
+}
+
 func (et *etcdKV) GetWithCopy(
 	key string,
 	copySelect kvdb.CopySelect,

--- a/kvdb.go
+++ b/kvdb.go
@@ -205,6 +205,15 @@ type EnumerateSelect func(val interface{}) bool
 // This fn should perform a deep copy of the input interface and return the copy
 type CopySelect func(val interface{}) interface{}
 
+// EnumerateKVPSelect function is a callback function provided to EnumerateKVPWithSelect API
+// This fn is executed over all the keys and only those values are returned by Enumerate for which
+// this function return true.
+type EnumerateKVPSelect func(kvp *KVPair, val interface{}) bool
+
+// CopyKVPSelect function is a callback function provided to EnumerateKVPWithSelect API
+// This fn should perform a deep copy of the input KVPair and return the copy
+type CopyKVPSelect func(kvp *KVPair, val interface{}) *KVPair
+
 // KVPair represents the results of an operation on KVDB.
 type KVPair struct {
 	// Key for this kv pair.
@@ -275,6 +284,9 @@ type Kvdb interface {
 	// EnumerateWithSelect returns a copy of all values under the prefix that satisfy the select
 	// function in the provided output array of interfaces
 	EnumerateWithSelect(prefix string, enumerateSelect EnumerateSelect, copySelect CopySelect) ([]interface{}, error)
+	// EnumerateKVPWithSelect returns a copy of all the KVPairs under the prefix that satisfy the select
+	// function in the provided output array of key-value pairs
+	EnumerateKVPWithSelect(prefix string, enumerateSelect EnumerateKVPSelect, copySelect CopyKVPSelect) (KVPairs, error)
 	// Delete deletes the KVPair specified by the key. ErrNotFound is returned
 	// if the key is not found. The old KVPair is returned if successful.
 	Delete(key string) (*KVPair, error)

--- a/wrappers/kv_log.go
+++ b/wrappers/kv_log.go
@@ -318,6 +318,20 @@ func (k *logKvWrapper) EnumerateWithSelect(
 	return vals, err
 }
 
+func (k *logKvWrapper) EnumerateKVPWithSelect(
+	prefix string,
+	enumerateSelect kvdb.EnumerateKVPSelect,
+	copySelect kvdb.CopyKVPSelect,
+) (kvdb.KVPairs, error) {
+	vals, err := k.wrappedKvdb.EnumerateKVPWithSelect(prefix, enumerateSelect, copySelect)
+	k.logger.WithFields(logrus.Fields{
+		opType:    "EnumerateKVPWithSelect",
+		"length":  len(vals),
+		errString: err,
+	}).Info()
+	return vals, err
+}
+
 func (k *logKvWrapper) GetWithCopy(
 	key string,
 	copySelect kvdb.CopySelect,

--- a/wrappers/kv_no_quorum.go
+++ b/wrappers/kv_no_quorum.go
@@ -166,6 +166,14 @@ func (k *noKvdbQuorumWrapper) EnumerateWithSelect(
 	return nil, kvdb.ErrNoQuorum
 }
 
+func (k *noKvdbQuorumWrapper) EnumerateKVPWithSelect(
+	prefix string,
+	enumerateSelect kvdb.EnumerateKVPSelect,
+	copySelect kvdb.CopyKVPSelect,
+) (kvdb.KVPairs, error) {
+	return nil, kvdb.ErrNoQuorum
+}
+
 func (k *noKvdbQuorumWrapper) GetWithCopy(
 	key string,
 	copySelect kvdb.CopySelect,

--- a/zookeeper/kv_zookeeper.go
+++ b/zookeeper/kv_zookeeper.go
@@ -294,6 +294,14 @@ func (z *zookeeperKV) EnumerateWithSelect(
 	return nil, kvdb.ErrNotSupported
 }
 
+func (z *zookeeperKV) EnumerateKVPWithSelect(
+	prefix string,
+	enumerateSelect kvdb.EnumerateKVPSelect,
+	copySelect kvdb.CopyKVPSelect,
+) (kvdb.KVPairs, error) {
+	return nil, kvdb.ErrNotSupported
+}
+
 func (z *zookeeperKV) Delete(key string) (*kvdb.KVPair, error) {
 	kvp, err := z.Get(key)
 	if err != nil {


### PR DESCRIPTION
- The existing EnumerateWithSelect API returns the actual interface values.
- The new EnumerateKVPsWithSelect API is similar but will return actual KVPairs instead.