### PR TITLE
Add BootstrapEntry data structure to kvdb API

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -34,7 +34,7 @@
   version = "v1.3.1-coreos.6"
 
 [[projects]]
-  digest = "1:b48a67766666526ee2641e9cbaf3134a49471addb515c340d2062e7856002b82"
+  digest = "1:34b80e6d27279735a8abf66cee67bde0f9011d3ff8e2812af6400ba498ec55c7"
   name = "github.com/coreos/etcd"
   packages = [
     "alarm",
@@ -89,8 +89,8 @@
     "wal/walpb",
   ]
   pruneopts = "UT"
-  revision = "28f3f26c0e303392556035b694f75768d449d33d"
-  version = "v3.3.1"
+  revision = "98d308426819d892e149fe45f6fd542464cb1f9d"
+  version = "v3.3.13"
 
 [[projects]]
   digest = "1:0ef770954bca104ee99b3b6b7f9b240605ac03517d9f98cbc1893daa03f3c038"
@@ -131,14 +131,6 @@
   pruneopts = "UT"
   revision = "06ea1031745cb8b3dab3f6a236daf2b0aa468b7e"
   version = "v3.2.0"
-
-[[projects]]
-  digest = "1:6f9339c912bbdda81302633ad7e99a28dfa5a639c864061f1929510a9a64aa74"
-  name = "github.com/dustin/go-humanize"
-  packages = ["."]
-  pruneopts = "UT"
-  revision = "9f541cc9db5d55bce703bd99987c9d5cb8eea45e"
-  version = "v1.0.0"
 
 [[projects]]
   digest = "1:a9c85389dbd301c97a3499fe15a2b65b505b5f0cb0f1120dea59f1f3d6b11d96"
@@ -271,6 +263,14 @@
   version = "v0.1.0"
 
 [[projects]]
+  digest = "1:7d7ccfe00918baede5a3daf233bad41bb922692f58a57a687f8b010e207a167b"
+  name = "github.com/json-iterator/go"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "a1ca0830781e007c66b225121d2cdb3a649421f6"
+  version = "v1.1.10"
+
+[[projects]]
   digest = "1:0a69a1c0db3591fcefb47f115b224592c8dfa4368b7ba9fae509d5e16cdc95c8"
   name = "github.com/konsorten/go-windows-terminal-sequences"
   packages = ["."]
@@ -301,6 +301,22 @@
   pruneopts = "UT"
   revision = "ae18d6b8b3205b561c79e8e5f69bff09736185f4"
   version = "v1.0.0"
+
+[[projects]]
+  digest = "1:33422d238f147d247752996a26574ac48dcf472976eda7f5134015f06bf16563"
+  name = "github.com/modern-go/concurrent"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "bacd9c7ef1dd9b15be4a9909b8ac7a4e313eec94"
+  version = "1.0.3"
+
+[[projects]]
+  digest = "1:e32bdbdb7c377a07a9a46378290059822efdce5c8d96fe71940d87cb4f918855"
+  name = "github.com/modern-go/reflect2"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "4b7aa43c6742a2c18fdef89dd197aaae7dac7ccd"
+  version = "1.0.1"
 
 [[projects]]
   branch = "master"
@@ -396,14 +412,6 @@
   pruneopts = "UT"
   revision = "ffdc059bfe9ce6a4e144ba849dbedead332c6053"
   version = "v1.3.0"
-
-[[projects]]
-  digest = "1:03aa6e485e528acb119fb32901cf99582c380225fc7d5a02758e08b180cb56c3"
-  name = "github.com/ugorji/go"
-  packages = ["codec"]
-  pruneopts = "UT"
-  revision = "b4c50a2b199d93b13dc15e78929cfb23bfdf21ab"
-  version = "v1.1.1"
 
 [[projects]]
   digest = "1:36775a135c00ff94c2ab9d4de842ae9bf95f45d2159ade2b033f3ecbafa69423"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -31,7 +31,7 @@
 
 [[constraint]]
   name = "github.com/coreos/etcd"
-  version = "=3.3.1"
+  version = "=3.3.13"
 
 [[constraint]]
   name = "google.golang.org/grpc"

--- a/api/bootstrap/bootstrap.go
+++ b/api/bootstrap/bootstrap.go
@@ -1,0 +1,77 @@
+package api
+
+import (
+	"time"
+)
+
+// BootstrapEntry identifies a node with its IP and ID which is part of a kvdb cluster
+type BootstrapEntry struct {
+	// IP of the kvdb node
+	IP string
+	// ID of the kvdb node
+	ID string
+	// Index of the kvdb node
+	Index int
+	// State indicates the state of the Node in the bootstrap state machine
+	State NodeState
+	// Type indicates the type of kvdb node
+	Type NodeType
+	// Ts is the last updated timestamp of this bootstrap entry
+	Ts time.Time
+	// Version is the bootstrap entry version
+	Version string
+	// used only for tests
+	// PeerPort is the peer port for kvdb node
+	PeerPort string `json:"peerport,omitemty"`
+	// ClientPort is the client port for kvdb node
+	ClientPort string `json:"clientport,omitempty"`
+	// Domain is the domain name advertised in the peer urls for this kvdb node
+	// The DomainName is only used for kvdb's peer urls.
+	// This enables us to change the actual peer IP being used by the nodes while keeping the domain
+	// name the same. The client url is always based of an IP.
+	Domain DomainName
+	// DataDirType is the type of data directory being used by internal kvdb on
+	// this node
+	DataDirType Type
+}
+
+// NodeState is the state of a kvdb bootstrap node
+type NodeState int
+
+const (
+	// BootstrapNodeStateNone indicates the init/none state
+	BootstrapNodeStateNone NodeState = iota
+	// BootstrapNodeStateInProgress bootstrap is in progress
+	BootstrapNodeStateInProgress
+	// BootstrapNodeStateOperational kvdb node is operational
+	BootstrapNodeStateOperational
+	// BootstrapNodeStateSuspectDown node is down
+	BootstrapNodeStateSuspectDown
+)
+
+// NodeType is a type that identifies the bootstrap node type
+type NodeType int
+
+const (
+	// BootstrapNodeTypeNone in default none type
+	BootstrapNodeTypeNone NodeType = iota
+	// BootstrapNodeTypeLeader node is a kvdb cluster leader
+	BootstrapNodeTypeLeader
+	// BootstrapNodeTypeMember node is a kvdb cluster member
+	BootstrapNodeTypeMember
+)
+
+// Type of datadir
+type Type string
+
+// DomainName identifies the DNS name internal kvdb node will use in the peer urls
+type DomainName string
+
+const (
+	// MetadataDevice when using a metadata device for internal kvdb data
+	MetadataDevice Type = "MetadataDevice"
+	// KvdbDevice when using a dedicated kvdb device for internal kvdb data
+	KvdbDevice Type = "KvdbDevice"
+	// BtrfsSubvolume when using btrfs subvolume from PX data drives for internal kvdb data
+	BtrfsSubvolume Type = "BtrfsSubvolume"
+)

--- a/api/bootstrap/k8s/k8s.go
+++ b/api/bootstrap/k8s/k8s.go
@@ -1,0 +1,16 @@
+package k8s
+
+import (
+	"regexp"
+	"strings"
+)
+
+var (
+	configMapNameRegex = regexp.MustCompile("[^a-zA-Z0-9]+")
+)
+
+// GetBootstrapConfigMapName returns the name of the config map used to bootstrap a PX kvdb cluster with the given
+// clusterID
+func GetBootstrapConfigMapName(clusterID string) string {
+	return "px-bootstrap-" + strings.ToLower(configMapNameRegex.ReplaceAllString(clusterID, ""))
+}


### PR DESCRIPTION
- Porting the BootstrapEntry from porx to here so external clients reading this data can unmarshall it
- Verified manually golint passes on the new package.


Signed-off-by: Harsh Desai <harsh@portworx.com>