### PR TITLE
etcd: use endpoint parameter instead of the ip+port pair

### DIFF
--- a/etcd/v3/kv_etcd.go
+++ b/etcd/v3/kv_etcd.go
@@ -1351,11 +1351,10 @@ func (et *etcdKV) RevokeUsersAccess(username string, permType kvdb.PermissionTyp
 }
 
 func (et *etcdKV) AddMember(
-	nodeIP string,
-	nodePeerPort string,
+	endpoint string,
 	nodeName string,
 ) (map[string][]string, error) {
-	peerURLs := et.listenPeerUrls(nodeIP, nodePeerPort)
+	peerURLs := et.listenPeerUrls(endpoint)
 	ctx, cancel := et.MaintenanceContextWithLeader()
 	_, err := et.kvClient.MemberAdd(ctx, peerURLs)
 	cancel()
@@ -1381,11 +1380,10 @@ func (et *etcdKV) AddMember(
 }
 
 func (et *etcdKV) UpdateMember(
-	nodeIP string,
-	nodePeerPort string,
+	endpoint string,
 	nodeName string,
 ) (map[string][]string, error) {
-	peerURLs := et.listenPeerUrls(nodeIP, nodePeerPort)
+	peerURLs := et.listenPeerUrls(endpoint)
 	ctx, cancel := et.MaintenanceContextWithLeader()
 
 	memberListResponse, err := et.kvClient.MemberList(ctx)
@@ -1419,7 +1417,7 @@ func (et *etcdKV) UpdateMember(
 
 func (et *etcdKV) RemoveMember(
 	nodeName string,
-	nodeIP string,
+	endpoint string,
 ) error {
 	fn := "RemoveMember"
 	ctx, cancel := et.MaintenanceContextWithLeader()
@@ -1437,7 +1435,7 @@ func (et *etcdKV) RemoveMember(
 		if member.Name == "" {
 			// In case of a failed start of an etcd member, the Name field will be empty
 			// We then try to match the IPs.
-			if strings.Contains(member.PeerURLs[0], nodeIP) {
+			if strings.Contains(member.PeerURLs[0], endpoint) {
 				removeMemberID = member.ID
 			}
 
@@ -1471,7 +1469,7 @@ func (et *etcdKV) RemoveMember(
 				return err
 			}
 			if i == (removeMemberRetries - 1) {
-				return fmt.Errorf("Too many retries for RemoveMember: %v %v", nodeName, nodeIP)
+				return fmt.Errorf("Too many retries for RemoveMember: %v %v", nodeName, endpoint)
 			}
 			time.Sleep(2 * time.Second)
 			continue
@@ -1501,13 +1499,15 @@ func (et *etcdKV) ListMembers() (map[string]*kvdb.MemberInfo, error) {
 		// etcd versions < v3.2.15 will return empty ClientURLs if
 		// the node is unhealthy. For versions >= v3.2.15 they populate
 		// ClientURLs but return an error status
-		if len(member.ClientURLs) != 0 {
+		// In case of https support, certificate can be generated just
+		// for one url, check each url.
+		for i := len(member.ClientURLs)-1; i >= 0; i-- {
 			// Use the context with no leader requirement as we might be hitting
 			// an endpoint which is down
 			ctx, cancel := et.MaintenanceContext()
 			endpointStatus, err := et.maintenanceClient.Status(
 				ctx,
-				member.ClientURLs[0],
+				member.ClientURLs[i],
 			)
 			cancel()
 			if err == nil {
@@ -1518,6 +1518,7 @@ func (et *etcdKV) ListMembers() (map[string]*kvdb.MemberInfo, error) {
 				isHealthy = true
 				// Only set the urls if status is healthy
 				clientURLs = member.ClientURLs
+				break
 			}
 		}
 		resp[member.Name] = &kvdb.MemberInfo{
@@ -1571,13 +1572,8 @@ func (et *etcdKV) Defragment(endpoint string, timeout int) error {
 
 }
 
-func (et *etcdKV) listenPeerUrls(ip string, port string) []string {
-	return []string{et.constructURL(ip, port)}
-}
-
-func (et *etcdKV) constructURL(ip string, port string) string {
-	ip = strings.TrimPrefix(ip, urlPrefix)
-	return urlPrefix + ip + ":" + port
+func (et *etcdKV) listenPeerUrls(endpoint string) []string {
+	return []string{endpoint}
 }
 
 func (et *etcdKV) getLeaseWithRetries(key string, ttl int64) (*e.LeaseGrantResponse, error) {

--- a/kvdb.go
+++ b/kvdb.go
@@ -415,15 +415,15 @@ type Controller interface {
 	// called on a kvdb node where kvdb is already running. It should be
 	// followed by a Setup call on the actual node
 	// Returns: map of nodeID to peerUrls of all members in the initial cluster or error
-	AddMember(nodeIP, nodePeerPort, nodeName string) (map[string][]string, error)
+	AddMember(endpoint, nodeName string) (map[string][]string, error)
 
 	// RemoveMember removes a member from an existing kvdb cluster
 	// Returns: error if it fails to remove a member
-	RemoveMember(nodeName, nodeIP string) error
+	RemoveMember(nodeName, endpoint string) error
 
 	// UpdateMember updates the IP for the given node in an existing kvdb cluster
 	// Returns: map of nodeID to peerUrls of all members from the existing cluster
-	UpdateMember(nodeIP, nodePeerPort, nodeName string) (map[string][]string, error)
+	UpdateMember(endpoint, nodeName string) (map[string][]string, error)
 
 	// ListMembers enumerates the members of the kvdb cluster
 	// Returns: the nodeID  to memberInfo mappings of all the members

--- a/kvdb_controller_not_supported.go
+++ b/kvdb_controller_not_supported.go
@@ -8,7 +8,7 @@ var (
 
 type controllerNotSupported struct{}
 
-func (c *controllerNotSupported) AddMember(nodeIP, nodePeerPort, nodeName string) (map[string][]string, error) {
+func (c *controllerNotSupported) AddMember(endpoint, nodeName string) (map[string][]string, error) {
 	return nil, ErrNotSupported
 }
 
@@ -16,7 +16,7 @@ func (c *controllerNotSupported) RemoveMember(nodeID string, nodeIP string) erro
 	return ErrNotSupported
 }
 
-func (c *controllerNotSupported) UpdateMember(nodeIP, nodePeerPort, nodeName string) (map[string][]string, error) {
+func (c *controllerNotSupported) UpdateMember(endpoint, nodeName string) (map[string][]string, error) {
 	return nil, ErrNotSupported
 }
 

--- a/test/kv.go
+++ b/test/kv.go
@@ -518,7 +518,7 @@ func concurrentEnum(kv kvdb.Kvdb, t *testing.T) {
 					key := fmt.Sprintf("%s/%d-%d", prefix, id, j%100000)
 					_, err := kv.Put(key, content, 0)
 					if err != nil {
-						logrus.WithError(err).Warnf("Error inserting key $s", key)
+						logrus.WithError(err).Warnf("Error inserting key %s", key)
 						numFails++
 						// let's tolerate some errors, since we're in race w/ Deleter
 						assert.True(t, numFails < 10, "Too many failures on PUT")

--- a/test/kv_controller.go
+++ b/test/kv_controller.go
@@ -66,7 +66,7 @@ func testAddMember(kv kvdb.Kvdb, t *testing.T) {
 	// Add node 1
 	index := 1
 	controllerLog("Adding node 1")
-	initCluster, err := kv.AddMember(localhost, peerPorts[index], names[index])
+	initCluster, err := kv.AddMember(constructURL(localhost, peerPorts[index]), names[index])
 	require.NoError(t, err, "Error on AddMember")
 	require.Equal(t, 2, len(initCluster), "Init Cluster length does not match")
 	cmd, err := startEtcd(index, initCluster, "existing")
@@ -84,7 +84,7 @@ func testRemoveMember(kv kvdb.Kvdb, t *testing.T) {
 	// Add node 2
 	index := 2
 	controllerLog("Adding node 2")
-	initCluster, err := kv.AddMember(localhost, peerPorts[index], names[index])
+	initCluster, err := kv.AddMember(constructURL(localhost, peerPorts[index]), names[index])
 	require.NoError(t, err, "Error on AddMember")
 	require.Equal(t, 3, len(initCluster), "Init Cluster length does not match")
 	cmd, err := startEtcd(index, initCluster, "existing")
@@ -123,7 +123,7 @@ func testReAdd(kv kvdb.Kvdb, t *testing.T) {
 	controllerLog("Re-adding node 1")
 	// For re-adding we need to delete the data-dir of this member
 	os.RemoveAll(dataDirs[index])
-	initCluster, err := kv.AddMember(localhost, peerPorts[index], names[index])
+	initCluster, err := kv.AddMember(constructURL(localhost, peerPorts[index]), names[index])
 	require.NoError(t, err, "Error on AddMember")
 	require.Equal(t, 3, len(initCluster), "Init Cluster length does not match")
 	cmd, err := startEtcd(index, initCluster, "existing")
@@ -148,7 +148,7 @@ func testUpdateMember(kv kvdb.Kvdb, t *testing.T) {
 	peerPorts[index] = "33380"
 
 	// Update the member
-	initCluster, err := kv.UpdateMember(localhost, peerPorts[index], names[index])
+	initCluster, err := kv.UpdateMember(constructURL(localhost, peerPorts[index]), names[index])
 	require.NoError(t, err, "Error on UpdateMember")
 	require.Equal(t, 3, len(initCluster), "Initial cluster length does not match")
 	cmd, err = startEtcd(index, initCluster, "existing")
@@ -160,7 +160,7 @@ func testUpdateMember(kv kvdb.Kvdb, t *testing.T) {
 	require.Equal(t, 3, len(list), "List returned different length of cluster")
 
 	// Update an invalid member
-	_, err = kv.UpdateMember(localhost, peerPorts[index], "foobar")
+	_, err = kv.UpdateMember(constructURL(localhost, peerPorts[index]), "foobar")
 	require.EqualError(t, kvdb.ErrMemberDoesNotExist, err.Error(), "Unexpected error on UpdateMember")
 }
 
@@ -183,7 +183,7 @@ func testMemberStatus(kv kvdb.Kvdb, t *testing.T) {
 
 	index := 3
 	controllerLog("Adding node 3")
-	initCluster, err := kv.AddMember(localhost, peerPorts[index], names[index])
+	initCluster, err := kv.AddMember(constructURL(localhost, peerPorts[index]), names[index])
 	require.NoError(t, err, "Error on AddMember")
 	cmd, err := startEtcd(index, initCluster, "existing")
 	require.NoError(t, err, "Error on start etcd")
@@ -194,7 +194,7 @@ func testMemberStatus(kv kvdb.Kvdb, t *testing.T) {
 
 	index = 4
 	controllerLog("Adding node 4")
-	initCluster, err = kv.AddMember(localhost, peerPorts[index], names[index])
+	initCluster, err = kv.AddMember(constructURL(localhost, peerPorts[index]), names[index])
 	require.NoError(t, err, "Error on AddMember")
 	cmd, err = startEtcd(index, initCluster, "existing")
 	require.NoError(t, err, "Error on start etcd")
@@ -330,4 +330,9 @@ func controllerLog(log string) {
 	fmt.Println("--------------------")
 	fmt.Println(log)
 	fmt.Println("--------------------")
+}
+
+func constructURL(ip string, port string) string {
+	ip = strings.TrimPrefix(ip, urlPrefix)
+	return urlPrefix + ip + ":" + port
 }

--- a/wrappers/kv_log.go
+++ b/wrappers/kv_log.go
@@ -428,8 +428,8 @@ func (k *logKvWrapper) Deserialize(b []byte) (kvdb.KVPairs, error) {
 	return k.wrappedKvdb.Deserialize(b)
 }
 
-func (k *logKvWrapper) AddMember(nodeIP, nodePeerPort, nodeName string) (map[string][]string, error) {
-	members, err := k.wrappedKvdb.AddMember(nodeIP, nodePeerPort, nodeName)
+func (k *logKvWrapper) AddMember(endpoint, nodeName string) (map[string][]string, error) {
+	members, err := k.wrappedKvdb.AddMember(endpoint, nodeName)
 	k.logger.WithFields(logrus.Fields{
 		opType:    "AddMember",
 		output:    members,
@@ -447,8 +447,8 @@ func (k *logKvWrapper) RemoveMember(nodeName, nodeIP string) error {
 	return err
 }
 
-func (k *logKvWrapper) UpdateMember(nodeIP, nodePeerPort, nodeName string) (map[string][]string, error) {
-	members, err := k.wrappedKvdb.UpdateMember(nodeIP, nodePeerPort, nodeName)
+func (k *logKvWrapper) UpdateMember(endpoint, nodeName string) (map[string][]string, error) {
+	members, err := k.wrappedKvdb.UpdateMember(endpoint, nodeName)
 	k.logger.WithFields(logrus.Fields{
 		opType:    "UpdateMember",
 		output:    members,

--- a/wrappers/kv_no_quorum.go
+++ b/wrappers/kv_no_quorum.go
@@ -233,7 +233,7 @@ func (k *noKvdbQuorumWrapper) Deserialize(b []byte) (kvdb.KVPairs, error) {
 	return nil, kvdb.ErrNoQuorum
 }
 
-func (k *noKvdbQuorumWrapper) AddMember(nodeIP, nodePeerPort, nodeName string) (map[string][]string, error) {
+func (k *noKvdbQuorumWrapper) AddMember(endpoint, nodeName string) (map[string][]string, error) {
 	return nil, kvdb.ErrNoQuorum
 }
 
@@ -241,8 +241,8 @@ func (k *noKvdbQuorumWrapper) RemoveMember(nodeName, nodeIP string) error {
 	return kvdb.ErrNoQuorum
 }
 
-func (k *noKvdbQuorumWrapper) UpdateMember(nodeIP, nodePeerPort, nodeName string) (map[string][]string, error) {
-	return k.wrappedKvdb.UpdateMember(nodeIP, nodePeerPort, nodeName)
+func (k *noKvdbQuorumWrapper) UpdateMember(endpoint, nodeName string) (map[string][]string, error) {
+	return k.wrappedKvdb.UpdateMember(endpoint, nodeName)
 }
 
 func (k *noKvdbQuorumWrapper) ListMembers() (map[string]*kvdb.MemberInfo, error) {


### PR DESCRIPTION
Currently the etcd implementation accepts ip+port pair and builds a url with the http scheme. Use endpoint parameter instead of ip+port pair, this provides a way to build the etcd url on the user side with a custom scheme.

Signed-off-by: Serhii Aheienko <serhii.aheienko@gmail.com>