### PR TITLE
retry the lock operation only when someone else is holding the lock

### DIFF
--- a/etcd/v3/kv_etcd.go
+++ b/etcd/v3/kv_etcd.go
@@ -696,7 +696,10 @@ func (et *etcdKV) LockWithTimeout(
 	lockTag := ec.LockerIDInfo{LockerID: lockerID}
 	kvPair, err := et.Create(key, lockTag, ttl)
 	startTime := time.Now()
-	for count := 0; err != nil; count++ {
+
+	// Create() will return ErrExist if the lock is being held already. In that case,
+	// we need to retry.
+	for count := 0; err == kvdb.ErrExist; count++ {
 		time.Sleep(duration)
 		kvPair, err = et.Create(key, lockTag, ttl)
 		if count > 0 && count%15 == 0 && err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:

We were retrying the lock operation for 5 minutes on all the errors. Create()
ends up calling LeaseWithRetries() which has 30 retries with 2 sec sleep.
If kvdb is down, the 5 min wait was causing unnecessary delay. Now, we use
the 5 minutes timeout only when someone is holding the lock.


**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:

