### PR TITLE
PWX-21389: `etcd3.Keys()` fix and optimization

### DIFF
--- a/etcd/v3/kv_etcd_test.go
+++ b/etcd/v3/kv_etcd_test.go
@@ -185,6 +185,7 @@ func TestKeys(t *testing.T) {
 		{"foo", []string{"keys"}},
 		{"foo/keys", []string{"key1", "key2", "key3d"}},
 		{"foo/keys/non-existent", []string{}},
+		{"foo/keys/key3", []string{}},
 		{"foo/keys/key3d", []string{"key3", "key3b"}},
 	}
 	for i, td := range results {
@@ -201,6 +202,24 @@ func TestKeys(t *testing.T) {
 	results = results[1:] // the first test will not work on 3rd pass -- let's skip it
 	for i, td := range results {
 		res, err := kv.Keys(td.input+"/", "/")
+		assert.NoError(t, err, "Unexpected error on test# %d : %v", i+1, td)
+		assert.Equal(t, td.expected, res, "Unexpected result on test# %d : %v", i+1, td)
+	}
+
+	// using different separator ('e')
+	results = []struct {
+		input    string
+		expected []string
+	}{
+		{"", []string{"foo/k"}},
+		{"foo/keys/non-existent", []string{}},
+		{"foo/ke", []string{"ys/k"}},
+		{"foo/k", []string{"ys/k"}},
+		{"foo/keys/ke", []string{"y1", "y2", "y3d/k"}},
+		{"foo/keys/k", []string{"y1", "y2", "y3d/k"}},
+	}
+	for i, td := range results {
+		res, err := kv.Keys(td.input, "e")
 		assert.NoError(t, err, "Unexpected error on test# %d : %v", i+1, td)
 		assert.Equal(t, td.expected, res, "Unexpected result on test# %d : %v", i+1, td)
 	}

--- a/etcd/v3/kv_etcd_test.go
+++ b/etcd/v3/kv_etcd_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/portworx/kvdb/etcd/common"
 	"github.com/portworx/kvdb/test"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
@@ -148,6 +149,61 @@ func testWithRestarts(t *testing.T, testFn func(chan int, kvdb.Kvdb, *kvdb.KVPai
 	case <-lockChan:
 	}
 
+}
+
+func TestKeys(t *testing.T) {
+	err := common.TestStart(true)
+	require.NoError(t, err, "Unable to start kvdb")
+	kv := newKv(t)
+	require.NotNil(t, kv)
+
+	data := []struct {
+		key, val string
+	}{
+		{"foo/keys/key1", "val1"},
+		{"foo/keys/key2", "val2"},
+		{"foo/keys/key3d/key3", "val3"},
+		{"foo/keys/key3d/key3b", "val3b"},
+	}
+	defer func() {
+		kv.DeleteTree("foo/keys")
+	}()
+
+	// load the data
+	for i, td := range data {
+		_, err := kv.Put(td.key, []byte(td.val), 0)
+		assert.NoError(t, err, "Unxpected error in Put on test# %d : %v", i+1, td)
+	}
+
+	// check the Keys()
+	results := []struct {
+		input    string
+		expected []string
+	}{
+		{"", []string{"foo"}},
+		{"non-existent", []string{}},
+		{"foo", []string{"keys"}},
+		{"foo/keys", []string{"key1", "key2", "key3d"}},
+		{"foo/keys/non-existent", []string{}},
+		{"foo/keys/key3d", []string{"key3", "key3b"}},
+	}
+	for i, td := range results {
+		res, err := kv.Keys(td.input, "/")
+		assert.NoError(t, err, "Unexpected error on test# %d : %v", i+1, td)
+		assert.Equal(t, td.expected, res, "Unexpected result on test# %d : %v", i+1, td)
+	}
+	for i, td := range results {
+		res, err := kv.Keys(td.input, "")
+		assert.NoError(t, err, "Unexpected error on test# %d : %v", i+1, td)
+		assert.Equal(t, td.expected, res, "Unexpected result on test# %d : %v", i+1, td)
+	}
+
+	results = results[1:] // the first test will not work on 3rd pass -- let's skip it
+	for i, td := range results {
+		res, err := kv.Keys(td.input+"/", "/")
+		assert.NoError(t, err, "Unexpected error on test# %d : %v", i+1, td)
+		assert.Equal(t, td.expected, res, "Unexpected result on test# %d : %v", i+1, td)
+	}
 }
 
 func newKv(t *testing.T) kvdb.Kvdb {


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
The `etcd3.Keys()` method was FAILING when user-authentication was turned on:
* switched from `--from-key` to `--prefix` handling  (see test-results below)
* "stop-condition" no longer an issue, so we could reduce the # of retrievals from etcd

**Which issue(s) this PR fixes** (optional)
Closes # PWX-21389

**Special notes for your reviewer**:

**Test case**
Setup:
```bash
etcdctl user add root	# set password 'Password1' when prompted
etcdctl user add zox	# set password 'FooBar' whem prompted
etcdctl --user root:Password1 user grant-role root root
etcdctl --user root:Password1 auth enable

# set up role `pwx` that has read-write perm on `pwx/` prefix, assign to User-account
etcdctl --user root:Password1 role add pwx
etcdctl --user root:Password1 user grant-role zox pwx
etcdctl --user root:Password1 role grant-permission pwx readwrite --prefix=true pwx/
# load some test-data into the etcd...
```
Test#1: using `--from-key`
```bash
# using `--from-key`, Admin access WORKS!!
ETCDCTL_API=3 \etcdctl get --user root:Password1 --from-key --keys-only /
# using `--from-key`, User access FAILS!!
ETCDCTL_API=3 \etcdctl get --user zox:FooBar --from-key --keys-only /
{"level":"warn","ts":"2021-09-30T23:10:04.897-0700","logger":"etcd-client","caller":"v3/retry_interceptor.go:62","msg":"retrying of unary invoker failed","target":"etcd-endpoints://0xc0004ae380/#initially=[127.0.0.1:2379]","attempt":0,"error":"rpc error: code = PermissionDenied desc = etcdserver: permission denied"}
Error: etcdserver: permission denied
```
* the `--from-key` has an issue when browsing AuthN-protected Etcd3  (works for root, but FAILS for regular users)
* see Test#2 for alternative way:

Test#2: using `--prefix`
```bash
# using `--prefix`, both Admin and User access WORK!!
ETCDCTL_API=3 \etcdctl get --user root:Password1 --prefix pwx/zoeleni0/lic/ --keys-only
ETCDCTL_API=3 \etcdctl get --user zox:FooBar --prefix pwx/zoeleni0/lic/ --keys-only
```

The `Test#1` was the original implementation of `etcd3.Keys()` method, which does not work properly when AuthN is turned on.
The `Test#2` is the re-implementation w/ this PR, that **works properly** with or without AuthN.  Also, since "stop condition" is no longer an issue, we were able to optimize the number of calls / retrievals to etcd  (e.g. only 1 retrieval, then pruned from memory).