### PR TITLE
PWX-21544: add a method to run compaction on the KVDB

### DIFF
--- a/bolt/kv_bolt.go
+++ b/bolt/kv_bolt.go
@@ -849,6 +849,10 @@ func (kv *boltKV) WatchTree(
 	return nil
 }
 
+func (kv *boltKV) Compact(index uint64) error {
+	return kvdb.ErrNotSupported
+}
+
 func (kv *boltKV) Lock(key string) (*kvdb.KVPair, error) {
 	return kv.LockWithID(key, "locked")
 }

--- a/consul/client.go
+++ b/consul/client.go
@@ -212,7 +212,7 @@ func newKvClient(machine string, p connectionParams) (*api.Config, *api.Client, 
 
 	client, err := api.NewClient(config)
 	if err != nil {
-		logrus.Info("consul: failed to get new api client: %v", err)
+		logrus.Warnf("consul: failed to get new api client: %v", err)
 		return nil, nil, err
 	}
 

--- a/consul/kv_consul.go
+++ b/consul/kv_consul.go
@@ -548,6 +548,10 @@ func (kv *consulKV) WatchTree(prefix string, waitIndex uint64, opaque interface{
 	return nil
 }
 
+func (kv *consulKV) Compact(index uint64) error {
+	return kvdb.ErrNotSupported
+}
+
 func (kv *consulKV) Lock(key string) (*kvdb.KVPair, error) {
 	return kv.LockWithID(key, "locked")
 }

--- a/etcd/v2/kv_etcd.go
+++ b/etcd/v2/kv_etcd.go
@@ -355,6 +355,12 @@ func (kv *etcdKV) WatchTree(
 	return nil
 }
 
+func (kv *etcdKV) Compact(
+	index uint64,
+) error {
+	return kvdb.ErrNotSupported
+}
+
 func (kv *etcdKV) Lock(key string) (*kvdb.KVPair, error) {
 	return kv.LockWithID(key, "locked")
 }

--- a/kvdb.go
+++ b/kvdb.go
@@ -350,6 +350,8 @@ type Kvdb interface {
 	Serialize() ([]byte, error)
 	// Deserialize deserializes the given byte array into a list of kv pairs
 	Deserialize([]byte) (KVPairs, error)
+	// Compact removes the history before the specified index/revision to reduce the space and memory usage
+	Compact(index uint64) error
 	KvdbWrapper
 }
 

--- a/mem/kv_mem.go
+++ b/mem/kv_mem.go
@@ -611,6 +611,12 @@ func (kv *memKV) WatchTree(
 	return nil
 }
 
+func (kv *memKV) Compact(
+	index uint64,
+) error {
+	return kvdb.ErrNotSupported
+}
+
 func (kv *memKV) Lock(key string) (*kvdb.KVPair, error) {
 	return kv.LockWithID(key, "locked")
 }

--- a/test/kv.go
+++ b/test/kv.go
@@ -518,7 +518,7 @@ func concurrentEnum(kv kvdb.Kvdb, t *testing.T) {
 					key := fmt.Sprintf("%s/%d-%d", prefix, id, j%100000)
 					_, err := kv.Put(key, content, 0)
 					if err != nil {
-						logrus.WithError(err).Warnf("Error inserting key $s", key)
+						logrus.WithError(err).Warnf("Error inserting key %s", key)
 						numFails++
 						// let's tolerate some errors, since we're in race w/ Deleter
 						assert.True(t, numFails < 10, "Too many failures on PUT")

--- a/wrappers/kv_log.go
+++ b/wrappers/kv_log.go
@@ -257,6 +257,17 @@ func (k *logKvWrapper) WatchTree(
 	return err
 }
 
+func (k *logKvWrapper) Compact(
+	index uint64,
+) error {
+	err := k.wrappedKvdb.Compact(index)
+	k.logger.WithFields(logrus.Fields{
+		opType:    "Compact",
+		errString: err,
+	}).Info()
+	return err
+}
+
 func (k *logKvWrapper) Lock(key string) (*kvdb.KVPair, error) {
 	pair, err := k.wrappedKvdb.Lock(key)
 	k.logger.WithFields(logrus.Fields{

--- a/wrappers/kv_no_quorum.go
+++ b/wrappers/kv_no_quorum.go
@@ -134,6 +134,12 @@ func (k *noKvdbQuorumWrapper) WatchTree(
 	return k.wrappedKvdb.WatchTree(prefix, waitIndex, opaque, cb)
 }
 
+func (k *noKvdbQuorumWrapper) Compact(
+	index uint64,
+) error {
+	return kvdb.ErrNoQuorum
+}
+
 func (k *noKvdbQuorumWrapper) Lock(key string) (*kvdb.KVPair, error) {
 	return nil, kvdb.ErrNoQuorum
 }

--- a/zookeeper/kv_zookeeper.go
+++ b/zookeeper/kv_zookeeper.go
@@ -445,6 +445,12 @@ func (z *zookeeperKV) WatchTree(
 	return kvdb.ErrNotSupported
 }
 
+func (z *zookeeperKV) Compact(
+	index uint64,
+) error {
+	return kvdb.ErrNotSupported
+}
+
 func (z *zookeeperKV) Snapshot(prefixes []string, consistent bool) (kvdb.Kvdb, uint64, error) {
 	return nil, 0, kvdb.ErrNotSupported
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
The consumer may want to control when a kvdb gets compacted. Added a method
to do that. Implemented the new method for etcd v3.

Fixed a few static-check warnings.

Signed-off-by: Neelesh Thakur <neelesh.thakur@purestorage.com>

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->



**Which issue(s) this PR fixes** (optional)
PWX-21544

**Special notes for your reviewer**:
The static-check fixes should not be causing any change in the logic.

