### PR TITLE
PWX-23111: Add IPv6 localhost '::1' as a defaultMachine.

### DIFF
--- a/etcd/v3/kv_etcd.go
+++ b/etcd/v3/kv_etcd.go
@@ -44,7 +44,7 @@ const (
 )
 
 var (
-	defaultMachines = []string{"http://127.0.0.1:2379"}
+	defaultMachines = []string{"http://127.0.0.1:2379", "http://[::1]:2379"}
 	// mLock is a lock over the maintenanceClient
 	mLock sync.Mutex
 )


### PR DESCRIPTION
Signed-off-by: Jose Rivera <jose@portworx.com>

**What this PR does / why we need it**:
To Support IPv6 we need to add the IPv6 localhost '::1'.  

**Which issue(s) this PR fixes** (optional)
Closes #
PWX-23111
**Special notes for your reviewer**:

