### PR TITLE
PWX-23502: populate the revision info after creating a key

### DIFF
--- a/etcd/v3/kv_etcd.go
+++ b/etcd/v3/kv_etcd.go
@@ -317,6 +317,7 @@ func (et *etcdKV) Create(
 
 	rangeResponse := txnResponse.Responses[1].GetResponseRange()
 	kvPair := et.resultToKv(rangeResponse.Kvs[0], "create")
+	kvPair.KVDBIndex = uint64(txnResponse.Header.Revision)
 	return kvPair, nil
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Populate the revision of the key that was just created. This may be
useful for some clients.

Signed-off-by: Neelesh Thakur <neelesh.thakur@purestorage.com>

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**Which issue(s) this PR fixes** (optional)
PWX-23502

**Special notes for your reviewer**:

