### PR TITLE
PWX-20808: etcd3 members list fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ services:
 - docker
 language: go
 go:
-- 1.10.7
+- 1.14.15
 install:
 - curl -s -L https://github.com/golang/dep/releases/download/v0.5.0/dep-linux-amd64 -o $GOPATH/bin/dep
 - chmod +x $GOPATH/bin/dep

--- a/test/kv_controller.go
+++ b/test/kv_controller.go
@@ -259,7 +259,7 @@ func testMemberStatus(kv kvdb.Kvdb, t *testing.T) {
 	select {
 	case <-c:
 		return
-	case <-time.After(5 * time.Minute):
+	case <-time.After(10 * time.Minute):
 		t.Fatalf("testMemberStatus timeout")
 	}
 }
@@ -306,6 +306,10 @@ func startEtcd(index int, initCluster map[string][]string, initState string) (*e
 		"--initial-cluster-state=" +
 			initState,
 	}
+
+	// unset env that can prevent etcd startup
+	os.Unsetenv("ETCD_LISTEN_CLIENT_URLS")
+	os.Unsetenv("ETCDCTL_API")
 
 	cmd := exec.Command("/tmp/test-etcd/etcd", etcdArgs...)
 	cmd.Stdout = ioutil.Discard


### PR DESCRIPTION
* will use configured KVDB endpoints first, for etcd3's ListMembers()
  - the client-URLs from MemberList() will be used as fail-back, to get status for members that were not registered as endpoints

Signed-off-by: Zoran Rajic <zrajic@purestorage.com>

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
The `ListMembers()` API for Etcd-v3 calls `MemberList()` first, then implicitly uses `Status()` on each ClientURL
* the issue with this is that server-side EtcD might be configured differently than provided client-endpoints  (e.g. use cluster-only hostnames/IPs, that are not accessible by the KVDB-clients)

FIX:
* we will inquire about the member's `Status()` by using the configured client-endpoints first
* if we didn't get all the members, as a failback we'll use `MemberList()` -provided endpoints to query the "missing" member's statuses

**Which issue(s) this PR fixes** (optional)
Closes # PWX-20808

**Special notes for your reviewer**:

Testing done ...

**Preparation**:
* configure 3-nodes EtcD with hostnames, e.g.:

```
# etcdctl --endpoints=http://init500-c24.dev.purestorage.com:3379 member list -w table
+------------------+---------+---------+---------------------------------------------+---------------------------------------------+------------+
|        ID        | STATUS  |  NAME   |                 PEER ADDRS                  |                CLIENT ADDRS                 | IS LEARNER |
+------------------+---------+---------+---------------------------------------------+---------------------------------------------+------------+
| 1b509e8a23d5c2bc | started | member1 | http://init500-c24.dev.purestorage.com:3380 | http://init500-c24.dev.purestorage.com:3379 |      false |
| 37876c8c6c9a757c | started | member2 | http://init500-c24.dev.purestorage.com:4380 | http://init500-c24.dev.purestorage.com:4379 |      false |
| 3705d7ea0766eac6 | started | member3 | http://init500-c24.dev.purestorage.com:5380 | http://init500-c24.dev.purestorage.com:5379 |      false |
+------------------+---------+---------+---------------------------------------------+---------------------------------------------+------------+
```

* configure PX with 2/3 EtcD endpoints, also use IP-addresses instead of hostnames  (so we can track the origin of information)
```
# /opt/pwx/bin/px-runc install -c zvm1 -k etcd://10.13.1.68:3379,etcd://10.13.1.68:4379 -s /dev/vdb
```

**Test 1**: list kvdb-members

```
# pxctl sv kvdb members list
Kvdb Cluster Members: 
ID	PEER URLs					CLIENT URLs					LEADER	HEALTHY	DBSIZE
member1	[http://init500-c24.dev.purestorage.com:3380]	[http://10.13.1.68:3379]			false	true	64 KiB
member2	[http://init500-c24.dev.purestorage.com:4380]	[http://10.13.1.68:4379]			true	true	64 KiB
member3	[http://init500-c24.dev.purestorage.com:5380]	[http://init500-c24.dev.purestorage.com:5379]	false	true	64 KiB
```
* note, we're getting 2/3 "CLIENT URLs" in IP-format, and 1/3 in hostname-format
* this is because 2/3 endpoints status is retrieved from original PX KVDB-endpoints config, while "missing" 1/3 endpoints status has been "completed" from the kvClient.MemberList()
* this way, we "prefer" status from PX KVDB-endpoints, and "fail back" (or "complete missing") endpoints statuses from MemberList()


**Test 2**: speed measurements  ("happy path")
* note, we used older EtcD 3.3.8, which is a bit slower on the responses
* also, we added special "time-measurement" logs, which are not included in the production code

```
# time =pxctl sv kvdb members list
Kvdb Cluster Members: 
ID	PEER URLs					CLIENT URLs					LEADER	HEALTHY	DBSIZE
member3	[http://init500-c24.dev.purestorage.com:5380]	[http://init500-c24.dev.purestorage.com:5379]	false	true	192 KiB
member2	[http://init500-c24.dev.purestorage.com:4380]	[http://10.13.1.68:4379]			true	true	192 KiB
member1	[http://init500-c24.dev.purestorage.com:3380]	[http://10.13.1.68:3379]			false	true	160 KiB

=pxctl sv kvdb members list  0.04s user 0.03s system 101% cpu 0.071 total

LOGS ::
Jul 06 13:32:59 zvm1 portworx[1339539]: time="2022-07-06T20:32:59Z" level=warning msg="DBG ZOX> MemberList() done in 1.192303ms" file="kv_etcd.go:1534" component=kvdb/etcd/v3 error="<nil>"
Jul 06 13:32:59 zvm1 portworx[1339539]: time="2022-07-06T20:32:59Z" level=warning msg="DBG ZOX> Status(http://10.13.1.68:3379) done in 1.773483ms" file="kv_etcd.go:1512" component=kvdb/etcd/v3 error="<nil>"
Jul 06 13:32:59 zvm1 portworx[1339539]: time="2022-07-06T20:32:59Z" level=warning msg="DBG ZOX> Status(http://10.13.1.68:4379) done in 1.223941ms" file="kv_etcd.go:1512" component=kvdb/etcd/v3 error="<nil>"
Jul 06 13:32:59 zvm1 portworx[1339539]: time="2022-07-06T20:32:59Z" level=warning msg="DBG ZOX> Status(http://init500-c24.dev.purestorage.com:5379) done in 1.221605ms" file="kv_etcd.go:1512" component=kvdb/etcd/v3 error="<nil>"
```
* note, when KVDB is operational, responses are very quick (few milliseconds)


**Test 3**: speed measurements  (1 KVDB member "down")

```
# time =pxctl sv kvdb members list
Kvdb Cluster Members: 
ID	PEER URLs					CLIENT URLs					LEADER	HEALTHY	DBSIZE
member1	[http://init500-c24.dev.purestorage.com:3380]	[]						false	false	0 B
member3	[http://init500-c24.dev.purestorage.com:5380]	[http://init500-c24.dev.purestorage.com:5379]	false	true	192 KiB
member2	[http://init500-c24.dev.purestorage.com:4380]	[http://10.13.1.68:4379]			true	true	192 KiB

=pxctl sv kvdb members list  0.10s user 0.09s system 0% cpu 21.804 total


Jul 06 13:31:43 zvm1 portworx[1339539]: time="2022-07-06T20:31:43Z" level=warning msg="DBG ZOX> MemberList() done in 1.358808ms" file="kv_etcd.go:1534" component=kvdb/etcd/v3 error="<nil>"
Jul 06 13:31:44 zvm1 portworx[1339539]: 2022-07-06_20:31:44: PX-Watchdog: (pid 7385): Using IPv4...
Jul 06 13:31:50 zvm1 portworx[1339539]: time="2022-07-06T20:31:50Z" level=warning msg="DBG ZOX> Status(http://10.13.1.68:3379) done in 7.000241192s" file="kv_etcd.go:1512" component=kvdb/etcd/v3 error="context deadline exceeded"
Jul 06 13:31:50 zvm1 portworx[1339539]: time="2022-07-06T20:31:50Z" level=warning msg="kvClient.Status(http://10.13.1.68:3379) returned error" file="kv_etcd.go:1548" component=kvdb/etcd/v3 error="context deadline exceeded"
Jul 06 13:31:53 zvm1 portworx[1339539]: time="2022-07-06T20:31:53Z" level=warning msg="DBG ZOX> Status(http://10.13.1.68:4379) done in 2.731314756s" file="kv_etcd.go:1512" component=kvdb/etcd/v3 error="<nil>"
Jul 06 13:32:00 zvm1 portworx[1339539]: time="2022-07-06T20:32:00Z" level=warning msg="DBG ZOX> Status(http://init500-c24.dev.purestorage.com:3379) done in 7.001005185s" file="kv_etcd.go:1512" component=kvdb/etcd/v3 error="context deadline exceeded"
Jul 06 13:32:00 zvm1 portworx[1339539]: time="2022-07-06T20:32:00Z" level=warning msg="kvClient.Status(http://init500-c24.dev.purestorage.com:3379) returned error" file="kv_etcd.go:1561" component=kvdb/etcd/v3 error="context deadline exceeded"
Jul 06 13:32:05 zvm1 portworx[1339539]: time="2022-07-06T20:32:05Z" level=warning msg="DBG ZOX> Status(http://init500-c24.dev.purestorage.com:5379) done in 5.000151352s" file="kv_etcd.go:1512" component=kvdb/etcd/v3 error="<nil>"
```
* note, we "emulate" the old code behavior, where "CLIENT URLs" is not populated for unhealthy KVDB-members
* note, we "doubled" the timeout compared to the old code, since inactive KVDB got queries twice  (7 sec timeout accessing `Status(http://10.13.1.68:3379)` and another 7 secs accessing "fail-back" `Status(http://init500-c24.dev.purestorage.com:3379)`)
* also note that all other KVDB calls are significantly slowed with KVDB members down  (they would be faster on newer version of KVDB)