### PR TITLE
PWX-27551-pt1: SSL fixes (kdb)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ services:
 - docker
 language: go
 go:
-- 1.14.15
+- 1.17.13
 install:
 - curl -s -L https://github.com/golang/dep/releases/download/v0.5.0/dep-linux-amd64 -o $GOPATH/bin/dep
 - chmod +x $GOPATH/bin/dep

--- a/etcd/common/common.go
+++ b/etcd/common/common.go
@@ -43,6 +43,9 @@ type EtcdCommon interface {
 
 	// GetRetryCount
 	GetRetryCount() int
+
+	// IsTLSEnabled returns TRUE if SSL is enabled in options
+	IsTLSEnabled() bool
 }
 
 // EtcdLock combines Mutex and channel
@@ -86,6 +89,14 @@ func (ec *etcdCommon) GetRetryCount() int {
 		return DefaultRetryCount
 	}
 	return int(retry)
+}
+
+func (ec *etcdCommon) IsTLSEnabled() bool {
+	// use `TransportScheme` hint if available
+	if ts, has := ec.options[kvdb.TransportScheme]; has {
+		return ts == "https"
+	}
+	return ec.options[kvdb.CertFileKey] != "" && ec.options[kvdb.CertKeyFileKey] != ""
 }
 
 func (ec *etcdCommon) GetAuthInfoFromOptions() (transport.TLSInfo, string, string, error) {

--- a/etcd/v3/kv_etcd.go
+++ b/etcd/v3/kv_etcd.go
@@ -39,6 +39,7 @@ const (
 	defaultKeepAliveTime    = 2 * time.Second
 	defaultKeepAliveTimeout = 6 * time.Second
 	urlPrefix               = "http://"
+	urlSecPrefix            = "https://"
 	// timeoutMaxRetry is maximum retries before faulting
 	timeoutMaxRetry = 30
 )
@@ -1622,8 +1623,12 @@ func (et *etcdKV) listenPeerUrls(ip string, port string) []string {
 }
 
 func (et *etcdKV) constructURL(ip string, port string) string {
-	ip = strings.TrimPrefix(ip, urlPrefix)
-	return urlPrefix + ip + ":" + port
+	prefix := urlPrefix
+	if et.EtcdCommon.IsTLSEnabled() {
+		prefix = urlSecPrefix
+	}
+	ip = strings.TrimPrefix(ip, prefix)
+	return prefix + ip + ":" + port
 }
 
 func (et *etcdKV) getLeaseWithRetries(key string, ttl int64) (*e.LeaseGrantResponse, error) {


### PR DESCRIPTION
* adding `IsTLSEnabled()` into etcd-common
  - `IsTLSEnabled()` returns TRUE if `options[TransportScheme]=https`, or if client SSL cert was provided
* the EtcD endpoint URLs will be prefixed either with http:// or https://

Signed-off-by: Zoran Rajic <zrajic@purestorage.com>

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
ISSUE:
* without this fix, the kvdb library always constructs non-SSL endpoints -- which is **wrong** if kvdb is running in SSL-mode

FIX:
* the caller can explicitly set `options[TransportScheme]=https` to enable SSL support, also
* if caller supplied end-client SSL certs, we'll also automatically enable SSL support

**Which issue(s) this PR fixes** (optional)
Closes # PWX-27551  (part 1)

**Special notes for your reviewer**:
This fix will be combined with the "part 2" fix in the `porx` code.