### PR TITLE
PWX-28882: Fix Nomad support issues for vSphere provider

### DIFF
--- a/bolt/kv_bolt.go
+++ b/bolt/kv_bolt.go
@@ -861,7 +861,7 @@ func (kv *boltKV) LockWithID(
 	key string,
 	lockerID string,
 ) (*kvdb.KVPair, error) {
-	return kv.LockWithTimeout(key, lockerID, kvdb.DefaultLockTryDuration, kv.GetLockTimeout())
+	return kv.LockWithTimeout(key, lockerID, kvdb.DefaultLockTryDuration, kv.GetLockHoldDuration())
 }
 
 func (kv *boltKV) LockWithTimeout(
@@ -946,6 +946,10 @@ func (kv *boltKV) EnumerateWithSelect(
 	copySelect kvdb.CopySelect,
 ) ([]interface{}, error) {
 	return nil, kvdb.ErrNotSupported
+}
+
+func (kv *boltKV) IsKeyLocked(key string) (bool, string, error) {
+	return false, "", kvdb.ErrNotSupported
 }
 
 func (kv *boltKV) EnumerateKVPWithSelect(

--- a/common/common.go
+++ b/common/common.go
@@ -32,12 +32,15 @@ func ToBytes(val interface{}) ([]byte, error) {
 
 // BaseKvdb provides common functionality across kvdb types
 type BaseKvdb struct {
-	// LockTimeout is the maximum time any lock can be held
-	LockTimeout time.Duration
+	// LockHoldTimeout is the maximum time any lock can be held
+	LockHoldTimeout time.Duration
 	// FatalCb invoked for fatal errors
 	FatalCb kvdb.FatalErrorCB
 	// lock to guard updates to timeout and fatalCb
 	lock sync.Mutex
+	// LockTryDuration is the max duration for which an attempt
+	// will be made to acquire a kvdb lock
+	LockTryDuration time.Duration
 }
 
 func (b *BaseKvdb) WrapperName() kvdb.WrapperName {
@@ -62,13 +65,19 @@ func (b *BaseKvdb) SetFatalCb(f kvdb.FatalErrorCB) {
 	b.FatalCb = f
 }
 
-// SetLockTimeout has property such that if the lock is held past this duration,
+// SetLockHoldDuration has property such that if the lock is held past this duration,
 // then a configured fatal callback is called.
-func (b *BaseKvdb) SetLockTimeout(timeout time.Duration) {
+func (b *BaseKvdb) SetLockHoldDuration(timeout time.Duration) {
 	b.lock.Lock()
 	defer b.lock.Unlock()
-	logrus.Infof("Setting lock timeout to: %v", timeout)
-	b.LockTimeout = timeout
+	logrus.Infof("Setting lock hold duration to: %v", timeout)
+	b.LockHoldTimeout = timeout
+}
+
+func (b *BaseKvdb) GetLockTryDuration() time.Duration {
+	b.lock.Lock()
+	defer b.lock.Unlock()
+	return b.LockTryDuration
 }
 
 // CheckLockTimeout checks lock timeout.
@@ -84,11 +93,11 @@ func (b *BaseKvdb) CheckLockTimeout(
 	}
 }
 
-// GetLockTimeout gets lock timeout.
-func (b *BaseKvdb) GetLockTimeout() time.Duration {
+// GetLockHoldDuration gets lock timeout.
+func (b *BaseKvdb) GetLockHoldDuration() time.Duration {
 	b.lock.Lock()
 	defer b.lock.Unlock()
-	return b.LockTimeout
+	return b.LockHoldTimeout
 }
 
 // LockTimedout does lock timedout.

--- a/consul/kv_consul.go
+++ b/consul/kv_consul.go
@@ -165,7 +165,7 @@ func New(
 		}
 		if config, client, err = newKvClient(machine, connParams); err == nil {
 			return &consulKV{
-				BaseKvdb:   common.BaseKvdb{FatalCb: connParams.fatalErrorCb},
+				BaseKvdb:   common.BaseKvdb{FatalCb: connParams.fatalErrorCb, LockTryDuration: kvdb.DefaultLockTryDuration},
 				domain:     domain,
 				Controller: kvdb.ControllerNotSupported,
 				client:     newConsulClient(config, client, refreshDelay, connParams),
@@ -560,7 +560,7 @@ func (kv *consulKV) LockWithID(key string, lockerID string) (
 	*kvdb.KVPair,
 	error,
 ) {
-	return kv.LockWithTimeout(key, lockerID, kvdb.DefaultLockTryDuration, kv.GetLockTimeout())
+	return kv.LockWithTimeout(key, lockerID, kv.LockTryDuration, kv.GetLockHoldDuration())
 }
 
 func (kv *consulKV) LockWithTimeout(
@@ -596,6 +596,17 @@ func (kv *consulKV) LockWithTimeout(
 		Key:  key,
 		Lock: l,
 	}, nil
+}
+
+func (kv *consulKV) IsKeyLocked(key string) (bool, string, error) {
+	kvPair, err := kv.Get(key)
+	if err == kvdb.ErrNotFound {
+		return false, "", nil
+	} else if err != nil {
+		return false, "", err
+	}
+	lockerID := string(kvPair.Value)
+	return true, lockerID, nil
 }
 
 func (kv *consulKV) Unlock(kvp *kvdb.KVPair) error {

--- a/etcd/v2/kv_etcd.go
+++ b/etcd/v2/kv_etcd.go
@@ -82,7 +82,7 @@ func New(
 		domain = domain + "/"
 	}
 	return &etcdKV{
-		common.BaseKvdb{FatalCb: fatalErrorCb},
+		common.BaseKvdb{FatalCb: fatalErrorCb, LockTryDuration: kvdb.DefaultLockTryDuration},
 		e.NewKeysAPI(c),
 		e.NewAuthUserAPI(c),
 		e.NewAuthRoleAPI(c),
@@ -369,7 +369,7 @@ func (kv *etcdKV) LockWithID(key string, lockerID string) (
 	*kvdb.KVPair,
 	error,
 ) {
-	return kv.LockWithTimeout(key, lockerID, kvdb.DefaultLockTryDuration, kv.GetLockTimeout())
+	return kv.LockWithTimeout(key, lockerID, kv.LockTryDuration, kv.GetLockHoldDuration())
 }
 
 func (kv *etcdKV) LockWithTimeout(
@@ -408,6 +408,10 @@ func (kv *etcdKV) LockWithTimeout(
 	go kv.refreshLock(kvPair, lockerID, lockHoldDuration)
 
 	return kvPair, err
+}
+
+func (kv *etcdKV) IsKeyLocked(key string) (bool, string, error) {
+	return false, "", fmt.Errorf("Not implemented")
 }
 
 func (kv *etcdKV) Unlock(kvp *kvdb.KVPair) error {

--- a/kvdb.go
+++ b/kvdb.go
@@ -328,6 +328,8 @@ type Kvdb interface {
 	// The KVPair returned should be used to unlock if successful.
 	LockWithTimeout(key string, lockerID string, lockTryDuration time.Duration,
 		lockHoldDuration time.Duration) (*KVPair, error)
+	// IsKeyLocked returns a boolean if the lock is held or not. If held, returns the owner.
+	IsKeyLocked(key string) (bool, string, error)
 	// Unlock kvp previously acquired through a call to lock.
 	Unlock(kvp *KVPair) error
 	// TxNew returns a new Tx coordinator object or ErrNotSupported
@@ -342,10 +344,12 @@ type Kvdb interface {
 	RevokeUsersAccess(username string, permType PermissionType, subtree string) error
 	// SetFatalCb sets the function to be called in case of fatal errors
 	SetFatalCb(f FatalErrorCB)
-	// SetLockTimeout sets maximum time a lock may be held
-	SetLockTimeout(timeout time.Duration)
-	// GetLockTimeout gets the currently set lock timeout
-	GetLockTimeout() time.Duration
+	// SetLockHoldDuration sets maximum time a lock may be held
+	SetLockHoldDuration(timeout time.Duration)
+	// GetLockTryDuration gets the maximum time to attempt to get a lock.
+	GetLockTryDuration() time.Duration
+	// GetLockHoldDuration gets the currently set lock hold timeout
+	GetLockHoldDuration() time.Duration
 	// Serialize serializes all the keys under the domain and returns a byte array
 	Serialize() ([]byte, error)
 	// Deserialize deserializes the given byte array into a list of kv pairs

--- a/mem/kv_mem.go
+++ b/mem/kv_mem.go
@@ -219,7 +219,7 @@ func New(
 	}
 
 	mem := &memKV{
-		BaseKvdb:   common.BaseKvdb{FatalCb: fatalErrorCb},
+		BaseKvdb:   common.BaseKvdb{FatalCb: fatalErrorCb, LockTryDuration: kvdb.DefaultLockTryDuration},
 		m:          make(map[string]*memKVPair),
 		dist:       NewWatchDistributor(),
 		domain:     domain,
@@ -625,7 +625,25 @@ func (kv *memKV) LockWithID(
 	key string,
 	lockerID string,
 ) (*kvdb.KVPair, error) {
-	return kv.LockWithTimeout(key, lockerID, kvdb.DefaultLockTryDuration, kv.GetLockTimeout())
+	return kv.LockWithTimeout(key, lockerID, kv.LockTryDuration, kv.GetLockHoldDuration())
+}
+
+func (kv *memKV) IsKeyLocked(key string) (bool, string, error) {
+	key = kv.domain + key
+	kv.mutex.Lock()
+	if _, ok := kv.locks[key]; !ok {
+		kv.mutex.Unlock()
+		return false, "", kvdb.ErrInvalidLock
+	}
+	kv.mutex.Unlock()
+	var lockerID string
+	_, err := kv.GetVal(key, &lockerID)
+	if err == kvdb.ErrNotFound {
+		return false, "", nil
+	} else if err != nil {
+		return false, "", err
+	}
+	return true, lockerID, nil
 }
 
 func (kv *memKV) LockWithTimeout(

--- a/test/kv.go
+++ b/test/kv.go
@@ -746,7 +746,7 @@ func lock(kv kvdb.Kvdb, t *testing.T) {
 	lockMethods := getLockMethods(kv)
 
 	for _, lockMethod := range lockMethods {
-		kv.SetLockTimeout(time.Duration(0))
+		kv.SetLockHoldDuration(time.Duration(0))
 		fmt.Println("lock")
 
 		key := "locktest"
@@ -836,13 +836,13 @@ func lock(kv kvdb.Kvdb, t *testing.T) {
 			lockTimedout = true
 		}
 		kv.SetFatalCb(fatalLockCb)
-		kv.SetLockTimeout(5 * time.Second)
-		assert.Equal(t, kv.GetLockTimeout(), 5*time.Second, "get lock timeout")
+		kv.SetLockHoldDuration(5 * time.Second)
+		assert.Equal(t, kv.GetLockHoldDuration(), 5*time.Second, "get lock timeout")
 		kvPair2, err = lockMethod("key2")
 		time.Sleep(15 * time.Second)
 		assert.True(t, lockTimedout, "lock timeout not called")
 		err = kv.Unlock(kvPair2)
-		kv.SetLockTimeout(5 * time.Second)
+		kv.SetLockHoldDuration(5 * time.Second)
 	}
 }
 

--- a/wrappers/kv_log.go
+++ b/wrappers/kv_log.go
@@ -291,6 +291,10 @@ func (k *logKvWrapper) LockWithID(
 	return pair, err
 }
 
+func (k *logKvWrapper) IsKeyLocked(key string) (bool, string, error) {
+	return k.wrappedKvdb.IsKeyLocked(key)
+}
+
 func (k *logKvWrapper) LockWithTimeout(
 	key string,
 	lockerID string,
@@ -423,12 +427,16 @@ func (k *logKvWrapper) SetFatalCb(f kvdb.FatalErrorCB) {
 	k.wrappedKvdb.SetFatalCb(f)
 }
 
-func (k *logKvWrapper) SetLockTimeout(timeout time.Duration) {
-	k.wrappedKvdb.SetLockTimeout(timeout)
+func (k *logKvWrapper) SetLockHoldDuration(timeout time.Duration) {
+	k.wrappedKvdb.SetLockHoldDuration(timeout)
 }
 
-func (k *logKvWrapper) GetLockTimeout() time.Duration {
-	return k.wrappedKvdb.GetLockTimeout()
+func (k *logKvWrapper) GetLockTryDuration() time.Duration{
+	return k.wrappedKvdb.GetLockTryDuration()
+}
+
+func (k *logKvWrapper) GetLockHoldDuration() time.Duration {
+	return k.wrappedKvdb.GetLockHoldDuration()
 }
 
 func (k *logKvWrapper) Serialize() ([]byte, error) {

--- a/wrappers/kv_no_quorum.go
+++ b/wrappers/kv_no_quorum.go
@@ -13,6 +13,7 @@ type noKvdbQuorumWrapper struct {
 	randGen *rand.Rand
 }
 
+
 // NewNoKvdbQuorumWrapper constructs a new kvdb.Kvdb.
 func NewNoKvdbQuorumWrapper(
 	kv kvdb.Kvdb,
@@ -75,6 +76,10 @@ func (k *noKvdbQuorumWrapper) Update(
 	ttl uint64,
 ) (*kvdb.KVPair, error) {
 	return nil, kvdb.ErrNoQuorum
+}
+
+func (k *noKvdbQuorumWrapper) GetLockTryDuration() time.Duration{
+	return k.wrappedKvdb.GetLockTryDuration()
 }
 
 func (k *noKvdbQuorumWrapper) Enumerate(prefix string) (kvdb.KVPairs, error) {
@@ -142,6 +147,10 @@ func (k *noKvdbQuorumWrapper) Compact(
 
 func (k *noKvdbQuorumWrapper) Lock(key string) (*kvdb.KVPair, error) {
 	return nil, kvdb.ErrNoQuorum
+}
+
+func (k *noKvdbQuorumWrapper) IsKeyLocked(key string) (bool, string, error) {
+	return false, "", kvdb.ErrNoQuorum
 }
 
 func (k *noKvdbQuorumWrapper) LockWithID(
@@ -223,12 +232,12 @@ func (k *noKvdbQuorumWrapper) SetFatalCb(f kvdb.FatalErrorCB) {
 	k.wrappedKvdb.SetFatalCb(f)
 }
 
-func (k *noKvdbQuorumWrapper) SetLockTimeout(timeout time.Duration) {
-	k.wrappedKvdb.SetLockTimeout(timeout)
+func (k *noKvdbQuorumWrapper) SetLockHoldDuration(timeout time.Duration) {
+	k.wrappedKvdb.SetLockHoldDuration(timeout)
 }
 
-func (k *noKvdbQuorumWrapper) GetLockTimeout() time.Duration {
-	return k.wrappedKvdb.GetLockTimeout()
+func (k *noKvdbQuorumWrapper) GetLockHoldDuration() time.Duration {
+	return k.wrappedKvdb.GetLockHoldDuration()
 }
 
 func (k *noKvdbQuorumWrapper) Serialize() ([]byte, error) {

--- a/zookeeper/kv_zookeeper.go
+++ b/zookeeper/kv_zookeeper.go
@@ -92,7 +92,8 @@ func newClient(
 
 	return &zookeeperKV{
 		BaseKvdb: common.BaseKvdb{
-			FatalCb: fatalErrorCb,
+			FatalCb:         fatalErrorCb,
+			LockTryDuration: kvdb.DefaultLockTryDuration,
 		},
 		client:     zkClient,
 		domain:     domain,
@@ -464,7 +465,7 @@ func (z *zookeeperKV) Lock(key string) (*kvdb.KVPair, error) {
 }
 
 func (z *zookeeperKV) LockWithID(key, lockerID string) (*kvdb.KVPair, error) {
-	return z.LockWithTimeout(key, lockerID, kvdb.DefaultLockTryDuration, z.GetLockTimeout())
+	return z.LockWithTimeout(key, lockerID, z.LockTryDuration, z.GetLockHoldDuration())
 }
 
 func (z *zookeeperKV) LockWithTimeout(
@@ -500,6 +501,10 @@ func (z *zookeeperKV) LockWithTimeout(
 	kvPair.Lock = &zookeeperLock{Done: make(chan struct{})}
 	go z.waitForUnlock(kvPair, lockerID, lockHoldDuration)
 	return kvPair, err
+}
+
+func (z *zookeeperKV) IsKeyLocked(key string) (bool, string, error) {
+	return false, "", kvdb.ErrNotSupported
 }
 
 func (z *zookeeperKV) waitForUnlock(

--- a/zookeeper/kv_zookeeper_test.go
+++ b/zookeeper/kv_zookeeper_test.go
@@ -151,7 +151,7 @@ func testLockBetweenClientRestarts(t *testing.T) {
 	assert.NoError(t, err, "Unable to create a client")
 	assert.NotNil(t, zk)
 
-	zk.SetLockTimeout(time.Minute)
+	zk.SetLockHoldDuration(time.Minute)
 
 	// Lock before restarting client
 	kvPair, err := zk.Lock("lock_key")
@@ -189,7 +189,7 @@ func testLockWithIDBetweenClientRestarts(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, zk)
 
-	zk.SetLockTimeout(time.Minute)
+	zk.SetLockHoldDuration(time.Minute)
 
 	// Lock before restarting client
 	kvPair, err := zk.LockWithID("lock_key", "lock_with_id")
@@ -227,7 +227,7 @@ func testLockWithTimeoutBetweenClientRestarts(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, zk)
 
-	zk.SetLockTimeout(time.Minute)
+	zk.SetLockHoldDuration(time.Minute)
 
 	// Lock before restarting client
 	kvPair, err := zk.LockWithTimeout("lock_key", "lock_with_id",


### PR DESCRIPTION
  Configmap apis were used in vSphere provider which stopped px from
  coming up on Nomad. The following changes are made
        - Store interface moved to cloudops
        - DriveSetStore interface created with Store as composite. Contains
          interfaces with DriveSet datastructure.
        - GetLockTryDuration introduced
        - Renamed GetLockTimeout/SetLockTimeout to
          GetLockHoldTimeout/SetLockHoldTimeout.
        - Implemented IsKeyLocked() and LockWithKey() interfaces in kv_store
        - Removed noOpStore implementation. It was a stop gap solution for
          locak of implementation in kv_store

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:

