### PR TITLE
PWX-28113: Fix ListMembers API and add a new RemoveMemberByID API.

### DIFF
--- a/etcd/v3/kv_etcd.go
+++ b/etcd/v3/kv_etcd.go
@@ -46,8 +46,8 @@ const (
 
 var (
 	defaultMachines = []string{"http://127.0.0.1:2379", "http://[::1]:2379"}
-	// mLock is a lock over the maintenanceClient
-	mLock sync.Mutex
+	// maintenanceClientLock is a lock over the maintenanceClient
+	maintenanceClientLock sync.Mutex
 )
 
 // watchQ to collect updates without blocking
@@ -1455,7 +1455,6 @@ func (et *etcdKV) RemoveMember(
 	nodeName string,
 	nodeIP string,
 ) error {
-	fn := "RemoveMember"
 	ctx, cancel := et.MaintenanceContextWithLeader()
 	memberListResponse, err := et.kvClient.MemberList(ctx)
 	cancel()
@@ -1484,9 +1483,15 @@ func (et *etcdKV) RemoveMember(
 	}
 	et.kvClient.SetEndpoints(newClientUrls...)
 	et.maintenanceClient.SetEndpoints(newClientUrls...)
+
+	return et.removeMember(removeMemberID)
+}
+
+func (et *etcdKV) removeMember(removeMemberID uint64) error {
+	fn := "removeMember"
 	removeMemberRetries := 5
 	for i := 0; i < removeMemberRetries; i++ {
-		ctx, cancel = et.MaintenanceContextWithLeader()
+		ctx, cancel := et.MaintenanceContextWithLeader()
 		_, err := et.kvClient.MemberRemove(ctx, removeMemberID)
 		cancel()
 
@@ -1497,13 +1502,13 @@ func (et *etcdKV) RemoveMember(
 				return nil
 			}
 			// Check if we need to retry
-			retry, err := isRetryNeeded(err, fn, nodeName, i)
+			retry, err := isRetryNeeded(err, fn, "", i)
 			if !retry {
 				// For all others return immediately
 				return err
 			}
 			if i == (removeMemberRetries - 1) {
-				return fmt.Errorf("too many retries for RemoveMember: %v %v", nodeName, nodeIP)
+				return fmt.Errorf("too many retries for RemoveMember: %v", removeMemberID)
 			}
 			time.Sleep(2 * time.Second)
 			continue
@@ -1513,7 +1518,53 @@ func (et *etcdKV) RemoveMember(
 	return nil
 }
 
-func (et *etcdKV) ListMembers() (map[string]*kvdb.MemberInfo, error) {
+func (et *etcdKV) RemoveMemberByID(
+	removeMemberID uint64,
+) error {
+	ctx, cancel := et.MaintenanceContextWithLeader()
+	memberListResponse, err := et.kvClient.MemberList(ctx)
+	cancel()
+	if err != nil {
+		return err
+	}
+	var (
+		removeMemberClientURLs, newClientURLs []string
+		found                                 bool
+	)
+
+	for _, member := range memberListResponse.Members {
+		if member.ID == removeMemberID {
+			found = true
+			removeMemberClientURLs = append(removeMemberClientURLs, member.ClientURLs...)
+		}
+	}
+	if !found {
+		// Member does not exist
+		return nil
+	}
+	currentEndpoints := et.kvClient.Endpoints()
+
+	// Remove the clientURLs for the member which is being removed from
+	// the active set of endpoints
+	for _, currentEndpoint := range currentEndpoints {
+		found := false
+		for _, removeClientURL := range removeMemberClientURLs {
+			if removeClientURL == currentEndpoint {
+				found = true
+			}
+		}
+		if !found {
+			newClientURLs = append(newClientURLs, currentEndpoint)
+		}
+	}
+
+	et.kvClient.SetEndpoints(newClientURLs...)
+	et.maintenanceClient.SetEndpoints(newClientURLs...)
+
+	return et.removeMember(removeMemberID)
+}
+
+func (et *etcdKV) ListMembers() (map[uint64]*kvdb.MemberInfo, error) {
 	var (
 		fnMemberStatus = func(cliURL string) (*kvdb.MemberInfo, uint64, error) {
 			if cliURL == "" {
@@ -1549,8 +1600,8 @@ func (et *etcdKV) ListMembers() (map[string]*kvdb.MemberInfo, error) {
 	}
 
 	membersMap := make(map[uint64]*kvdb.MemberInfo)
-	mLock.Lock()
-	defer mLock.Unlock()
+	maintenanceClientLock.Lock()
+	defer maintenanceClientLock.Unlock()
 
 	// Get status from Endpoints
 	for _, ep := range et.GetEndpoints() {
@@ -1577,22 +1628,24 @@ func (et *etcdKV) ListMembers() (map[string]*kvdb.MemberInfo, error) {
 		}
 	}
 
-	// Fill PeerURLs; also, remap with "Name" as a key
-	resp := make(map[string]*kvdb.MemberInfo)
+	// Fill in other details in the MemberInfo object
 	for _, member := range memberListResponse.Members {
 		if mi, has := membersMap[member.ID]; has {
 			mi.PeerUrls = member.PeerURLs
-			resp[member.Name] = mi
+			mi.Name = member.Name
+			mi.HasStarted = len(member.Name) > 0
 		} else {
 			// no status -- add "blank" MemberInfo
-			resp[member.Name] = &kvdb.MemberInfo{
-				PeerUrls: member.PeerURLs,
-				ID:       strconv.FormatUint(member.ID, 16),
+			membersMap[member.ID] = &kvdb.MemberInfo{
+				PeerUrls:   member.PeerURLs,
+				Name:       member.Name,
+				HasStarted: len(member.Name) > 0,
+				ID:         strconv.FormatUint(member.ID, 16),
 			}
 		}
 	}
 
-	return resp, nil
+	return membersMap, nil
 }
 
 func (et *etcdKV) Serialize() ([]byte, error) {

--- a/etcd/v3/kv_etcd.go
+++ b/etcd/v3/kv_etcd.go
@@ -1484,6 +1484,10 @@ func (et *etcdKV) RemoveMember(
 	et.kvClient.SetEndpoints(newClientUrls...)
 	et.maintenanceClient.SetEndpoints(newClientUrls...)
 
+	if removeMemberID == uint64(0) {
+		// Member not found. No need to remove it
+		return nil
+	}
 	return et.removeMember(removeMemberID)
 }
 
@@ -1536,6 +1540,7 @@ func (et *etcdKV) RemoveMemberByID(
 		if member.ID == removeMemberID {
 			found = true
 			removeMemberClientURLs = append(removeMemberClientURLs, member.ClientURLs...)
+			break
 		}
 	}
 	if !found {
@@ -1551,6 +1556,7 @@ func (et *etcdKV) RemoveMemberByID(
 		for _, removeClientURL := range removeMemberClientURLs {
 			if removeClientURL == currentEndpoint {
 				found = true
+				break
 			}
 		}
 		if !found {

--- a/kvdb_controller_not_supported.go
+++ b/kvdb_controller_not_supported.go
@@ -15,12 +15,15 @@ func (c *controllerNotSupported) AddMember(nodeIP, nodePeerPort, nodeName string
 func (c *controllerNotSupported) RemoveMember(nodeID string, nodeIP string) error {
 	return ErrNotSupported
 }
+func (c *controllerNotSupported) RemoveMemberByID(memberID uint64) error {
+	return ErrNotSupported
+}
 
 func (c *controllerNotSupported) UpdateMember(nodeIP, nodePeerPort, nodeName string) (map[string][]string, error) {
 	return nil, ErrNotSupported
 }
 
-func (c *controllerNotSupported) ListMembers() (map[string]*MemberInfo, error) {
+func (c *controllerNotSupported) ListMembers() (map[uint64]*MemberInfo, error) {
 	return nil, ErrNotSupported
 }
 

--- a/test/kv.go
+++ b/test/kv.go
@@ -370,7 +370,7 @@ func deleteTree(kv kvdb.Kvdb, t *testing.T) {
 	prefix := "tree"
 	keys := map[string]string{
 		prefix + "/1cbc9a98-072a-4793-8608-01ab43db96c8": "bar",
-		prefix + "/foo":                                  "baz",
+		prefix + "/foo": "baz",
 	}
 
 	for key, val := range keys {
@@ -407,7 +407,7 @@ func enumerate(kv kvdb.Kvdb, t *testing.T) {
 	prefix := "enumerate"
 	keys := map[string]string{
 		prefix + "/1cbc9a98-072a-4793-8608-01ab43db96c8": "bar",
-		prefix + "/foo":                                  "baz",
+		prefix + "/foo": "baz",
 	}
 
 	kv.DeleteTree(prefix)

--- a/test/kv_controller.go
+++ b/test/kv_controller.go
@@ -21,11 +21,12 @@ const (
 )
 
 var (
-	names      = []string{"infra0", "infra1", "infra2", "infra3", "infra4"}
-	clientUrls = []string{"http://127.0.0.1:20379", "http://127.0.0.1:21379", "http://127.0.0.1:22379", "http://127.0.0.1:23379", "http://127.0.0.1:24379"}
-	peerPorts  = []string{"20380", "21380", "22380", "23380", "24380"}
-	dataDirs   = []string{"/tmp/node0", "/tmp/node1", "/tmp/node2", "/tmp/node3", "/tmp/node4"}
-	cmds       map[int]*exec.Cmd
+	names         = []string{"infra0", "infra1", "infra2", "infra3", "infra4"}
+	clientUrls    = []string{"http://127.0.0.1:20379", "http://127.0.0.2:21379", "http://127.0.0.3:22379", "http://127.0.0.4:23379", "http://127.0.0.5:24379"}
+	peerPorts     = []string{"20380", "21380", "22380", "23380", "24380"}
+	dataDirs      = []string{"/tmp/node0", "/tmp/node1", "/tmp/node2", "/tmp/node3", "/tmp/node4"}
+	cmds          map[int]*exec.Cmd
+	firstMemberID uint64
 )
 
 // RunControllerTests is a test suite for kvdb controller APIs
@@ -48,9 +49,16 @@ func RunControllerTests(datastoreInit kvdb.DatastoreInit, t *testing.T) {
 		t.Fatalf(err.Error())
 	}
 
+	memberList, err := kv.ListMembers()
+	require.NoError(t, err, "error on ListMembers")
+	require.Equal(t, 1, len(memberList), "incorrect number of members")
+	for id := range memberList {
+		firstMemberID = id
+		break
+	}
 	testAddMember(kv, t)
 	testRemoveMember(kv, t)
-	testReAdd(kv, t)
+	testReAddAndRemoveByMemberID(kv, t)
 	testUpdateMember(kv, t)
 	testMemberStatus(kv, t)
 	testDefrag(kv, t)
@@ -69,14 +77,47 @@ func testAddMember(kv kvdb.Kvdb, t *testing.T) {
 	initCluster, err := kv.AddMember(localhost, peerPorts[index], names[index])
 	require.NoError(t, err, "Error on AddMember")
 	require.Equal(t, 2, len(initCluster), "Init Cluster length does not match")
+
+	// Check for unstarted members
+	memberList, err := kv.ListMembers()
+	require.NoError(t, err, "error on ListMembers")
+	require.Equal(t, len(memberList), 2, "incorrect number of members")
+
+	for memberID, m := range memberList {
+		if memberID != firstMemberID {
+			require.Equal(t, len(m.ClientUrls), 0, "Unexpected no. of client urls on unstarted member")
+			require.False(t, m.IsHealthy, "Unexpected health of unstarted member")
+			require.Empty(t, m.Name, "expected name to be empty")
+			require.False(t, m.HasStarted, "expected member to be unstarted")
+			require.Equal(t, len(m.PeerUrls), 1, "peerURLs should be set for unstarted members")
+			require.Equal(t, m.DbSize, int64(0), "db size should be 0")
+		} else {
+			require.Equal(t, len(m.ClientUrls), 1, "clientURLs should be set for started members")
+			require.True(t, m.IsHealthy, "expected member to be healthy")
+			require.NotEmpty(t, m.Name, "expected name")
+			require.True(t, m.HasStarted, "expected member to be started")
+			require.Equal(t, len(m.PeerUrls), 1, "peerURLs should be set for started members")
+			require.NotEqual(t, m.DbSize, int64(0), "db size should not be 0")
+		}
+	}
+
 	cmd, err := startEtcd(index, initCluster, "existing")
 	require.NoError(t, err, "Error on start etcd")
 	cmds[index] = cmd
 
-	// Check the list returned
-	list, err := kv.ListMembers()
+	// Check the list again after starting the second member.
+	memberList, err = kv.ListMembers()
 	require.NoError(t, err, "Error on ListMembers")
-	require.Equal(t, 2, len(list), "List returned different length of cluster")
+	require.Equal(t, 2, len(memberList), "List returned different length of cluster")
+
+	for _, m := range memberList {
+		require.True(t, m.IsHealthy, "expected member to be healthy")
+		require.NotEmpty(t, m.Name, "expected name")
+		require.True(t, m.HasStarted, "expected member to be started")
+		require.Equal(t, len(m.PeerUrls), 1, "peerURLs should be set for started members")
+		require.Equal(t, len(m.ClientUrls), 1, "clientURLs should be set for started members")
+		require.NotEqual(t, m.DbSize, 0, "db size should not be 0")
+	}
 }
 
 func testRemoveMember(kv kvdb.Kvdb, t *testing.T) {
@@ -95,11 +136,20 @@ func testRemoveMember(kv kvdb.Kvdb, t *testing.T) {
 	require.NoError(t, err, "Error on ListMembers")
 	require.Equal(t, 3, len(list), "List returned different length of cluster")
 
+	// Before removing all endpoints should be set
+	require.Equal(t, len(clientUrls), len(kv.GetEndpoints()), "unexpected endpoints")
+
 	// Remove node 1
 	index = 1
 	controllerLog("Removing node 1")
 	err = kv.RemoveMember(names[index], localhost)
 	require.NoError(t, err, "Error on RemoveMember")
+
+	// Only 2 endpoints should be set and the third one should have been removed
+	require.Equal(t, 2, len(kv.GetEndpoints()), "unexpected endpoints")
+	for _, actualEndpoint := range kv.GetEndpoints() {
+		require.NotEqual(t, actualEndpoint, clientUrls[index], "removed member should not be present")
+	}
 
 	cmd, _ = cmds[index]
 	cmd.Process.Kill()
@@ -116,24 +166,65 @@ func testRemoveMember(kv kvdb.Kvdb, t *testing.T) {
 	require.NoError(t, err, "Error on RemoveMember")
 }
 
-func testReAdd(kv kvdb.Kvdb, t *testing.T) {
-	controllerLog("testReAdd")
+func testReAddAndRemoveByMemberID(kv kvdb.Kvdb, t *testing.T) {
+	controllerLog("testReAddAndRemoveByMemberID")
+
 	// Add node 1 back
-	index := 1
+	node1Index := 1
 	controllerLog("Re-adding node 1")
 	// For re-adding we need to delete the data-dir of this member
-	os.RemoveAll(dataDirs[index])
-	initCluster, err := kv.AddMember(localhost, peerPorts[index], names[index])
+	os.RemoveAll(dataDirs[node1Index])
+	initCluster, err := kv.AddMember(localhost, peerPorts[node1Index], names[node1Index])
 	require.NoError(t, err, "Error on AddMember")
 	require.Equal(t, 3, len(initCluster), "Init Cluster length does not match")
-	cmd, err := startEtcd(index, initCluster, "existing")
+	cmd, err := startEtcd(node1Index, initCluster, "existing")
 	require.NoError(t, err, "Error on start etcd")
-	cmds[index] = cmd
+	cmds[node1Index] = cmd
 
 	// Check the list returned
 	list, err := kv.ListMembers()
 	require.NoError(t, err, "Error on ListMembers")
 	require.Equal(t, 3, len(list), "List returned different length of cluster")
+
+	// Remove node 1
+	var removeMemberID uint64
+	for memberID, member := range list {
+		if member.Name == names[node1Index] {
+			removeMemberID = memberID
+			break
+		}
+	}
+	require.NotEqual(t, removeMemberID, 0, "unexpected memberID")
+
+	// Remove on non-existent member should succeed
+	err = kv.RemoveMemberByID(12345)
+	require.NoError(t, err, "unexpected error on removing a non-existent member")
+
+	err = kv.RemoveMemberByID(removeMemberID)
+	require.NoError(t, err, "unexpected error on remove")
+
+	// Only 2 endpoints should be set and the third one should have been removed
+	require.Equal(t, 2, len(kv.GetEndpoints()), "unexpected endpoints")
+	for _, actualEndpoint := range kv.GetEndpoints() {
+		require.NotEqual(t, actualEndpoint, clientUrls[node1Index], "removed member should not be present")
+	}
+
+	// Kill the old etcd process
+	cmd, _ = cmds[node1Index]
+	cmd.Process.Kill()
+	delete(cmds, node1Index)
+
+	// Add node 1 back
+	controllerLog("Re-adding node 1 again")
+	// For re-adding we need to delete the data-dir of this member
+	os.RemoveAll(dataDirs[node1Index])
+	initCluster, err = kv.AddMember(localhost, peerPorts[node1Index], names[node1Index])
+	require.NoError(t, err, "Error on AddMember")
+	require.Equal(t, 3, len(initCluster), "Init Cluster length does not match")
+	cmd, err = startEtcd(node1Index, initCluster, "existing")
+	require.NoError(t, err, "Error on start etcd")
+	cmds[node1Index] = cmd
+
 }
 
 func testUpdateMember(kv kvdb.Kvdb, t *testing.T) {
@@ -222,30 +313,24 @@ func testMemberStatus(kv kvdb.Kvdb, t *testing.T) {
 	var wg sync.WaitGroup
 	wg.Add(numOfGoroutines)
 
-	checkMembers := func(id string, wait int) {
+	checkMembers := func(index string, wait int) {
 		defer wg.Done()
 		// Add a sleep so that all go routines run just around the same time
 		time.Sleep(time.Duration(wait) * time.Second)
-		controllerLog("Listing Members for goroutine no. " + id)
+		controllerLog("Listing Members for goroutine no. " + index)
 		list, err := kv.ListMembers()
-		require.NoError(t, err, "%v: Error on ListMembers", id)
-		require.Equal(t, 5, len(list), "%v: List returned different length of cluster", id)
+		require.NoError(t, err, "%v: Error on ListMembers", index)
+		require.Equal(t, 5, len(list), "%v: List returned different length of cluster", index)
 
-		downMember, ok := list[names[stoppedIndex]]
-		require.True(t, ok, "%v: Could not find down member", id)
-		require.Equal(t, len(downMember.ClientUrls), 0, "%v: Unexpected no. of client urls on down member", id)
-		require.False(t, downMember.IsHealthy, "%v: Unexpected health of down member", id)
-
-		for name, m := range list {
-			if name == names[stoppedIndex] {
-				continue
+		for _, m := range list {
+			if m.Name == names[stoppedIndex] || m.Name == names[stoppedIndex2] {
+				require.Equal(t, len(m.ClientUrls), 0, "%v: Unexpected no. of client urls on down member", index)
+				require.False(t, m.IsHealthy, "%v: Unexpected health of down member", index)
+			} else {
+				require.True(t, m.IsHealthy, "%v: Expected member %v to be healthy", index, m.Name)
 			}
-			if name == names[stoppedIndex2] {
-				continue
-			}
-			require.True(t, m.IsHealthy, "%v: Expected member %v to be healthy", id, name)
 		}
-		fmt.Println("checkMembers done for ", id)
+		fmt.Println("checkMembers done for ", index)
 	}
 	for i := 0; i < numOfGoroutines; i++ {
 		go checkMembers(strconv.Itoa(i), numOfGoroutines-1)

--- a/wrappers/kv_log.go
+++ b/wrappers/kv_log.go
@@ -431,7 +431,7 @@ func (k *logKvWrapper) SetLockHoldDuration(timeout time.Duration) {
 	k.wrappedKvdb.SetLockHoldDuration(timeout)
 }
 
-func (k *logKvWrapper) GetLockTryDuration() time.Duration{
+func (k *logKvWrapper) GetLockTryDuration() time.Duration {
 	return k.wrappedKvdb.GetLockTryDuration()
 }
 
@@ -466,6 +466,15 @@ func (k *logKvWrapper) RemoveMember(nodeName, nodeIP string) error {
 	return err
 }
 
+func (k *logKvWrapper) RemoveMemberByID(removeMemberID uint64) error {
+	err := k.wrappedKvdb.RemoveMemberByID(removeMemberID)
+	k.logger.WithFields(logrus.Fields{
+		opType:    "RemoveMemberByID",
+		errString: err,
+	}).Info()
+	return err
+}
+
 func (k *logKvWrapper) UpdateMember(nodeIP, nodePeerPort, nodeName string) (map[string][]string, error) {
 	members, err := k.wrappedKvdb.UpdateMember(nodeIP, nodePeerPort, nodeName)
 	k.logger.WithFields(logrus.Fields{
@@ -476,7 +485,7 @@ func (k *logKvWrapper) UpdateMember(nodeIP, nodePeerPort, nodeName string) (map[
 	return members, err
 }
 
-func (k *logKvWrapper) ListMembers() (map[string]*kvdb.MemberInfo, error) {
+func (k *logKvWrapper) ListMembers() (map[uint64]*kvdb.MemberInfo, error) {
 	members, err := k.wrappedKvdb.ListMembers()
 	k.logger.WithFields(logrus.Fields{
 		opType:    "ListMembers",

--- a/wrappers/kv_no_quorum.go
+++ b/wrappers/kv_no_quorum.go
@@ -13,7 +13,6 @@ type noKvdbQuorumWrapper struct {
 	randGen *rand.Rand
 }
 
-
 // NewNoKvdbQuorumWrapper constructs a new kvdb.Kvdb.
 func NewNoKvdbQuorumWrapper(
 	kv kvdb.Kvdb,
@@ -78,7 +77,7 @@ func (k *noKvdbQuorumWrapper) Update(
 	return nil, kvdb.ErrNoQuorum
 }
 
-func (k *noKvdbQuorumWrapper) GetLockTryDuration() time.Duration{
+func (k *noKvdbQuorumWrapper) GetLockTryDuration() time.Duration {
 	return k.wrappedKvdb.GetLockTryDuration()
 }
 
@@ -256,11 +255,15 @@ func (k *noKvdbQuorumWrapper) RemoveMember(nodeName, nodeIP string) error {
 	return kvdb.ErrNoQuorum
 }
 
+func (k *noKvdbQuorumWrapper) RemoveMemberByID(removeMemberID uint64) error {
+	return kvdb.ErrNoQuorum
+}
+
 func (k *noKvdbQuorumWrapper) UpdateMember(nodeIP, nodePeerPort, nodeName string) (map[string][]string, error) {
 	return k.wrappedKvdb.UpdateMember(nodeIP, nodePeerPort, nodeName)
 }
 
-func (k *noKvdbQuorumWrapper) ListMembers() (map[string]*kvdb.MemberInfo, error) {
+func (k *noKvdbQuorumWrapper) ListMembers() (map[uint64]*kvdb.MemberInfo, error) {
 	return k.wrappedKvdb.ListMembers()
 }
 


### PR DESCRIPTION


**What this PR does / why we need it**:
ListMembers API
- The ListMembers API used to return a map[string]*MemberInfo. The key to this map was the name of a member.
- However when there is unstarted etcd member, the name of the member is set to empty.
- Changed the API to return a map[uint64]*MemberInfo, where the key is a unique ID which is always set (even for unstarted members).
- Also added HasStarted and Name fields to MemberInfo for easy lookup.

RemoveMemberByID API
- Introduced a new API to remove members based on their IDs.

UTs
- Fixed existing UTs to handle the new API.
- Added tests for RemoveMemberByID API.
- Added more checks to existing UTs.


**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:

