### PR TITLE
PWX-30451: allow adding a new etcd member as a learner

### DIFF
--- a/etcd/v3/kv_etcd.go
+++ b/etcd/v3/kv_etcd.go
@@ -1389,9 +1389,31 @@ func (et *etcdKV) AddMember(
 	nodePeerPort string,
 	nodeName string,
 ) (map[string][]string, error) {
+	return et.addMember(nodeIP, nodePeerPort, nodeName, false)
+}
+
+func (et *etcdKV) AddLearner(
+	nodeIP string,
+	nodePeerPort string,
+	nodeName string,
+) (map[string][]string, error) {
+	return et.addMember(nodeIP, nodePeerPort, nodeName, true)
+}
+
+func (et *etcdKV) addMember(
+	nodeIP string,
+	nodePeerPort string,
+	nodeName string,
+	isLearner bool,
+) (map[string][]string, error) {
+	var err error
 	peerURLs := et.listenPeerUrls(nodeIP, nodePeerPort)
 	ctx, cancel := et.MaintenanceContextWithLeader()
-	_, err := et.kvClient.MemberAdd(ctx, peerURLs)
+	if isLearner {
+		_, err = et.kvClient.MemberAddAsLearner(ctx, peerURLs)
+	} else {
+		_, err = et.kvClient.MemberAdd(ctx, peerURLs)
+	}
 	cancel()
 	if err != nil {
 		return nil, err

--- a/kvdb.go
+++ b/kvdb.go
@@ -436,6 +436,10 @@ type Controller interface {
 	// Returns: map of nodeID to peerUrls of all members in the initial cluster or error.
 	AddMember(nodeIP, nodePeerPort, nodeName string) (map[string][]string, error)
 
+	// AddLearner is same as AddMember except that the new member is added as a learner.
+	// It is caller's responsibility to promote it to a full voting member.
+	AddLearner(nodeIP, nodePeerPort, nodeName string) (map[string][]string, error)
+
 	// RemoveMember removes a member based on its Name from an existing kvdb cluster.
 	// Returns: error if it fails to remove a member
 	RemoveMember(nodeName, nodeIP string) error

--- a/kvdb_controller_not_supported.go
+++ b/kvdb_controller_not_supported.go
@@ -12,6 +12,10 @@ func (c *controllerNotSupported) AddMember(nodeIP, nodePeerPort, nodeName string
 	return nil, ErrNotSupported
 }
 
+func (c *controllerNotSupported) AddLearner(nodeIP, nodePeerPort, nodeName string) (map[string][]string, error) {
+	return nil, ErrNotSupported
+}
+
 func (c *controllerNotSupported) RemoveMember(nodeID string, nodeIP string) error {
 	return ErrNotSupported
 }

--- a/mock/mock_kvdb.go
+++ b/mock/mock_kvdb.go
@@ -35,6 +35,21 @@ func (m *MockKvdb) EXPECT() *MockKvdbMockRecorder {
 	return m.recorder
 }
 
+// AddLearner mocks base method.
+func (m *MockKvdb) AddLearner(arg0, arg1, arg2 string) (map[string][]string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AddLearner", arg0, arg1, arg2)
+	ret0, _ := ret[0].(map[string][]string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// AddLearner indicates an expected call of AddLearner.
+func (mr *MockKvdbMockRecorder) AddLearner(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddLearner", reflect.TypeOf((*MockKvdb)(nil).AddLearner), arg0, arg1, arg2)
+}
+
 // AddMember mocks base method.
 func (m *MockKvdb) AddMember(arg0, arg1, arg2 string) (map[string][]string, error) {
 	m.ctrl.T.Helper()

--- a/wrappers/kv_log.go
+++ b/wrappers/kv_log.go
@@ -457,6 +457,16 @@ func (k *logKvWrapper) AddMember(nodeIP, nodePeerPort, nodeName string) (map[str
 	return members, err
 }
 
+func (k *logKvWrapper) AddLearner(nodeIP, nodePeerPort, nodeName string) (map[string][]string, error) {
+	members, err := k.wrappedKvdb.AddLearner(nodeIP, nodePeerPort, nodeName)
+	k.logger.WithFields(logrus.Fields{
+		opType:    "AddLearner",
+		output:    members,
+		errString: err,
+	}).Info()
+	return members, err
+}
+
 func (k *logKvWrapper) RemoveMember(nodeName, nodeIP string) error {
 	err := k.wrappedKvdb.RemoveMember(nodeName, nodeIP)
 	k.logger.WithFields(logrus.Fields{

--- a/wrappers/kv_no_quorum.go
+++ b/wrappers/kv_no_quorum.go
@@ -251,6 +251,10 @@ func (k *noKvdbQuorumWrapper) AddMember(nodeIP, nodePeerPort, nodeName string) (
 	return nil, kvdb.ErrNoQuorum
 }
 
+func (k *noKvdbQuorumWrapper) AddLearner(nodeIP, nodePeerPort, nodeName string) (map[string][]string, error) {
+	return nil, kvdb.ErrNoQuorum
+}
+
 func (k *noKvdbQuorumWrapper) RemoveMember(nodeName, nodeIP string) error {
 	return kvdb.ErrNoQuorum
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Adding as a learner provides better stability as per the etcd docs. Caller is responsible for promoting the learner to a full voting member.
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**Which issue(s) this PR fixes** (optional)
PWX-30451

**Special notes for your reviewer**:

