### PR TITLE
PWX-30841: use WithBlock in etcd v3 client config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 sudo: required
-dist: trusty
+dist: focal
 services:
 - docker
 language: go

--- a/etcd/v3/kv_etcd.go
+++ b/etcd/v3/kv_etcd.go
@@ -20,6 +20,7 @@ import (
 	"go.etcd.io/etcd/etcdserver/api/v3rpc/rpctypes"
 	"go.etcd.io/etcd/mvcc/mvccpb"
 	"golang.org/x/net/context"
+	"google.golang.org/grpc"
 )
 
 const (
@@ -151,6 +152,12 @@ func New(
 		TLS:                  tlsCfg,
 		DialKeepAliveTime:    defaultKeepAliveTime,
 		DialKeepAliveTimeout: defaultKeepAliveTimeout,
+
+		// As per the comment in go.etcd.io/etcd/clientv3/config.go, we need to pass "grpc.WithBlock()"
+		// to block until the underlying connection is up. Without this, Dial returns immediately and
+		// connecting the server happens in background. This is a behavior change in 3.4.
+		// We use WithBlock to preserve the old behavior.
+		DialOptions: []grpc.DialOption{grpc.WithBlock()},
 
 		// The time required for a request to fail - 30 sec
 		//HeaderTimeoutPerRequest: time.Duration(10) * time.Second,


### PR DESCRIPTION
**What this PR does / why we need it**:
We want to preserve the old behavior of the New() blocking until the underlying connection is established.

Also, changed dist to focal in travis config to avoid build failure.

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->



**Which issue(s) this PR fixes** (optional)
PWX-30841

**Special notes for your reviewer**:

