### PR TITLE
[PWX-32578] Explicitly add new member to initial-cluster if missing in memberlist

### DIFF
--- a/etcd/v3/kv_etcd.go
+++ b/etcd/v3/kv_etcd.go
@@ -1440,6 +1440,10 @@ func (et *etcdKV) addMember(
 			resp[member.Name] = member.PeerURLs
 		}
 	}
+	if _, ok := resp[nodeName]; !ok {
+		logrus.Warnf("%s not found in kvdb memberlist. Adding it explicitly.", nodeName)
+		resp[nodeName] = peerURLs
+	}
 	return resp, nil
 }
 


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
After addMember() to etcd4, this PR explicitly adds new member to memberlist returned by ETCDv4 if it is missing.
We have observed that after adding a new learner node to existing ETCD cluster (Probably, because of https://github.com/etcd-io/etcd/issues/11198 which is fixed in ETCD v3.5), this new learner node does 
not appear in memberlist immidately. Since, we get no error while adding a member, its safe to add to list of members .

(We are currently on ETCD v3.4.24)

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:

