### PR TITLE
Add check if kvp is nil for no quorum wrapper unlock

### DIFF
--- a/wrappers/kv_no_quorum.go
+++ b/wrappers/kv_no_quorum.go
@@ -169,6 +169,9 @@ func (k *noKvdbQuorumWrapper) LockWithTimeout(
 }
 
 func (k *noKvdbQuorumWrapper) Unlock(kvp *kvdb.KVPair) error {
+	if kvp == nil {
+		return kvdb.ErrEmptyValue
+	}
 	return k.wrappedKvdb.Unlock(kvp)
 }
 

--- a/wrappers/kv_no_quorum_test.go
+++ b/wrappers/kv_no_quorum_test.go
@@ -1,0 +1,34 @@
+package wrappers
+
+import (
+	"testing"
+	"time"
+
+	"github.com/portworx/kvdb"
+	"github.com/stretchr/testify/require"
+)
+
+// TestKVNoQuorumLock tests all functions related to kvp and locks
+func TestKVNoQuorumLock(t *testing.T) {
+	wrapper := noKvdbQuorumWrapper{}
+
+	kv, err := wrapper.LockWithID("key", "id")
+	require.Error(t, err)
+	require.ErrorIs(t, err, kvdb.ErrNoQuorum)
+	require.Nil(t, kv)
+
+	kv, err = wrapper.Lock("key")
+	require.Error(t, err)
+	require.ErrorIs(t, err, kvdb.ErrNoQuorum)
+	require.Nil(t, kv)
+
+	kv, err = wrapper.LockWithTimeout("key", "id", time.Hour, time.Hour)
+	require.Error(t, err)
+	require.ErrorIs(t, err, kvdb.ErrNoQuorum)
+	require.Nil(t, kv)
+
+	var kvp *kvdb.KVPair
+	err = wrapper.Unlock(kvp)
+	require.Error(t, err)
+	require.ErrorIs(t, err, kvdb.ErrEmptyValue)
+}


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
From PWX-32482, we saw a panic where no wrapper received an nil KVPair and propagates it to unlock. 
We should guard that and make sure kvp is not an empty pointer. 

**Which issue(s) this PR fixes** (optional)
PWX-32482

**Special notes for your reviewer**:
Add simple UT to test this. Before add the fix, it paniced too
```

Running tool: /dogfood-home/eng_home/dahuang/usr/local/go/bin/go test -timeout 30s -run ^TestKVNoQuorumLock$ github.com/portworx/kvdb/wrappers

=== RUN   TestKVNoQuorumLock
--- FAIL: TestKVNoQuorumLock (0.00s)
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
        panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x170 pc=0x593c02]

goroutine 6 [running]:
testing.tRunner.func1.2({0x5b8e80, 0x76fb00})
        /dogfood-home/eng_home/dahuang/usr/local/go/src/testing/testing.go:1526 +0x24e
testing.tRunner.func1()
        /dogfood-home/eng_home/dahuang/usr/local/go/src/testing/testing.go:1529 +0x39f
panic({0x5b8e80, 0x76fb00})
        /dogfood-home/eng_home/dahuang/usr/local/go/src/runtime/panic.go:884 +0x213
github.com/portworx/kvdb/wrappers.(*noKvdbQuorumWrapper).Unlock(...)
        /home/dahuang/go/src/github.com/portworx/kvdb/wrappers/kv_no_quorum.go:175
github.com/portworx/kvdb/wrappers.TestKVNoQuorumLock(0x0?)
        /home/dahuang/go/src/github.com/portworx/kvdb/wrappers/kv_no_quorum_test.go:31 +0x1e2
testing.tRunner(0xc0000dcd00, 0x617910)
        /dogfood-home/eng_home/dahuang/usr/local/go/src/testing/testing.go:1576 +0x10b
created by testing.(*T).Run
        /dogfood-home/eng_home/dahuang/usr/local/go/src/testing/testing.go:1629 +0x3ea
FAIL    github.com/portworx/kvdb/wrappers       0.005s
```
