### PR TITLE
Return error when GetVal gives error

### DIFF
--- a/etcd/v3/kv_etcd.go
+++ b/etcd/v3/kv_etcd.go
@@ -737,6 +737,7 @@ func (et *etcdKV) LockWithTimeout(
 			if _, errGet := et.GetVal(key, &currLockerTag); errGet == nil {
 				return nil, fmt.Errorf("failed to take a lock on %v: lock taken by: %v ", key, currLockerTag.LockerID)
 			}
+			return nil, fmt.Errorf("failed to take a lock on %v", key)
 		}
 	}
 	if err != nil {


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
An error is returned when GetVal() returns an error

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:

